### PR TITLE
Override presented URL domains in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
-=========
-presenter
-=========
+# presenter
+
 A component that builds and returns the final document.
 
-Installation
-------------
-With ``npm`` installed, run ``npm install`` from the root directory.
+## Installation
 
-Configuration
--------------
+With `npm` installed, run `npm install` from the root directory.
+
+## Configuration
+
 Set the following environment variables:
-``${MAPPING_SERVICE_URL}``: **Required**. URL of the mapping service.
-``${CONTENT_SERVICE_URL}``: **Required**. URL of the content service.
 
-Running Locally
----------------
-From the command line, run ``node app.js``.
+ * `MAPPING_SERVICE_URL`: **Required**. URL of the mapping service.
+
+ * `CONTENT_SERVICE_URL`: **Required**. URL of the content service.
+
+ * `PRESENTED_URL_HOST`: Use a constant instead of the `Host:` value as the base of the presented URL. Useful for development in environments without DNS.
+
+## Running Locally
+
+From the command line, run `node app.js`.
 
 Open a browser window and navigate to [http://localhost:8080](http://localhost:8080).
 
-Running Mock Mapping and Content Services
------------------------------------------
-The repo includes two files for mock services: ``fake_content_service.js`` and ``fake_mapping_service.js``.
-To run them, from the command line, run ``node fake_content_service.js`` and ``node fake_mapping_service.js``, respectively.
+## Running Mock Mapping and Content Services
+
+The repo includes two files for mock services: `fake_content_service.js` and `fake_mapping_service.js`. To run them, from the command line, run `node fake_content_service.js` and `node fake_mapping_service.js`, respectively.

--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ function normalize_url(url) {
 
 var mapping_service_url;
 var content_service_url;
+var presented_url_host = process.env.PRESENTED_URL_HOST;
 
 // TODO: create function that long-polls and waits for an etcd key change, then calls
 // get_mapping_service_url() and get_content_service_url() to update the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+---
+content:
+  image: deconst/content-service
+  environment:
+    RACKSPACE_USERNAME:
+    RACKSPACE_APIKEY:
+    RACKSPACE_REGION: DFW
+    RACKSPACE_CONTAINER: presenter-dev
+mapping:
+  image: deconst/mapping-service
+  environment:
+    MAPREPO_URL: https://github.com/deconst/map-example.git
+presenter:
+  build: .
+  links:
+  - content
+  - mapping
+  environment:
+    MAPPING_SERVICE_URL: http://mapping:9999/
+    CONTENT_SERVICE_URL: http://content:8080/
+    PRESENTED_URL_HOST: docker
+  ports:
+  - "80:8080"


### PR DESCRIPTION
Because you're unlikely to have DNS set up for your laptop for development, deriving the presented URL's domain from the incoming request's hostname is inconvenient. This introduces `PRESENTED_URL_HOST`, an optional configuration setting that allows you to override the domain.
