### PR TITLE
The presented URL should be a real URL.

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,7 +34,7 @@ function set_content_service_url() {
 // one is provided.
 function presented_url(req) {
   var domain = presented_url_domain ? presented_url_domain : req.hostname;
-  return domain + req.path;
+  return "https://" + domain + req.path;
 }
 
 set_mapping_service_url();


### PR DESCRIPTION
I added a fake scheme to the presented URL because:
1. The mapping service was written to assume that the presented URL is a full URL rather than domain-forward; and
2. I'd rather have something called a "URL" actually parse as one than fix it the other way.

See also deconst/deconst-docs#22.
