### PR TITLE
Port consistency in docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:0.10.36
 
-
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 RUN useradd node
@@ -9,7 +8,6 @@ COPY package.json /usr/src/app/
 RUN npm install
 COPY . /usr/src/app
 
-# replace this with your application's default port
 EXPOSE 8080
 
 USER node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,22 +8,22 @@ content:
     RACKSPACE_CONTAINER: presenter-dev
     CONTENT_LOG_LEVEL: DEBUG
   ports:
-  - "8080:8080"
+  - "9000:8080"
 mapping:
   image: deconst/mapping-service
   environment:
     CONTROL_REPO_URL: https://github.com/deconst/map-example.git
     MAP_LOG_LEVEL: DEBUG
   ports:
-  - "9999:9999"
+  - "9001:8080"
 presenter:
   build: .
   links:
   - content
   - mapping
   environment:
-    MAPPING_SERVICE_URL: http://mapping:9999/
-    CONTENT_SERVICE_URL: http://content:8080/
+    CONTENT_SERVICE_URL: http://content:9000/
+    MAPPING_SERVICE_URL: http://mapping:9001/
     PRESENTED_URL_DOMAIN: mysite.com
     PRESENTER_LOG_LEVEL: DEBUG
   ports:


### PR DESCRIPTION
Use the port mappings from deconst/deconst-docs#28 in docker-compose.
