### PR TITLE
Bring Travis up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 language: node_js
 sudo: false
 node_js:
-- "0.10.36"
-before_script:
+- "0.12.1"
+install:
 - npm install -g jshint
 script:
 - jshint .


### PR DESCRIPTION
Use node 0.12.1 to be consistent with the Dockerfile. Use `install:` instead of `before_script:` to install jshint.
