### PR TITLE
Translate contentIDs in results to presented URLs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,14 +18,14 @@ content:
 mapping:
   image: quay.io/deconst/mapping-service
   environment:
-    CONTROL_REPO_URL: https://github.com/deconst/map-example.git
+    CONTROL_REPO_URL: https://github.com/deconst/control-example.git
     MAP_LOG_LEVEL: DEBUG
   ports:
   - "9001:8080"
 layout:
   image: quay.io/deconst/layout-service
   environment:
-    CONTROL_REPO_URL: https://github.com/deconst/map-example.git
+    CONTROL_REPO_URL: https://github.com/deconst/control-example.git
     LAYOUT_LOG_LEVEL: DEBUG
   ports:
   - "9002:8080"
@@ -39,6 +39,7 @@ presenter:
     CONTENT_SERVICE_URL: http://content:8080/
     MAPPING_SERVICE_URL: http://mapping:8080/
     LAYOUT_SERVICE_URL: http://layout:8080/
+    PRESENTED_URL_PROTO: https
     PRESENTED_URL_DOMAIN: mysite.com
     PRESENTER_LOG_LEVEL: DEBUG
   ports:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "async": "^0.9.0",
     "express": "4.12.3",
     "handlebars": "3.0.0",
+    "lodash": "^3.8.0",
     "request": "2.53.0",
     "url-join": "0.0.1",
     "winston": "^0.9.0"

--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,11 @@ var configuration = {
     normalize: normalize_url,
     required: true
   },
+  presented_url_proto: {
+    env: "PRESENTED_URL_PROTO",
+    description: "Override the protocol of presented URLs",
+    required: false
+  },
   presented_url_domain: {
     env: "PRESENTED_URL_DOMAIN",
     description: "Override the domain of presented URLs",

--- a/src/config.js
+++ b/src/config.js
@@ -29,6 +29,16 @@ var configuration = {
     description: "Override the domain of presented URLs",
     required: false
   },
+  public_url_proto: {
+    env: "PUBLIC_URL_PROTO",
+    description: "Override the protocol of outgoing URLs",
+    required: false
+  },
+  public_url_domain: {
+    env: "PUBLIC_URL_DOMAIN",
+    description: "Override the domain of outgoing URLs",
+    required: false
+  },
   log_level: {
     env: "PRESENTER_LOG_LEVEL",
     description: "Log level for the presenter.",

--- a/src/content.js
+++ b/src/content.js
@@ -2,6 +2,7 @@
 
 var
   request = require('request'),
+  url = require('url'),
   urljoin = require('url-join'),
   async = require('async'),
   handlebars = require('handlebars'),
@@ -138,8 +139,27 @@ function related(content_doc, callback) {
             request(mapping_url, function (err, res, body) {
               if (err) return callback(err);
 
-              var doc = JSON.parse(body);
-              result.url = doc['presented-url'];
+              var
+                doc = JSON.parse(body),
+                u = doc['presented-url'],
+                domain = config.presented_url_domain(),
+                proto = config.presented_url_proto();
+
+              if (domain || proto) {
+                var parsed = url.parse(u);
+
+                if (domain) {
+                  parsed.host = domain;
+                }
+
+                if (proto) {
+                  parsed.protocol = proto;
+                }
+
+                u = url.format(parsed);
+              }
+
+              result.url = u;
 
               callback(null, result);
             });

--- a/src/content.js
+++ b/src/content.js
@@ -264,6 +264,8 @@ module.exports = function (req, res) {
     content_doc.has_next_or_previous =
       !!(content_doc.envelope.next || content_doc.envelope.previous);
 
+    logger.debug("Rendering final content document:", content_doc);
+
     var html = content_doc.layout(content_doc);
 
     res.send(html);

--- a/src/content.js
+++ b/src/content.js
@@ -21,11 +21,13 @@ var page500 = "<!DOCTYPE html>" +
   "</body>" +
   "</html>";
 
-// Derive the presented URL for a specific request, honoring the presented_url_domain setting if
-// one is provided.
+// Derive the presented URL for a specific request, honoring the presented_url_domain and
+// presented_url_proto settings if provided.
 function presented_url(req) {
+  var proto = config.presented_url_proto() || req.protocol;
   var domain = config.presented_url_domain() || req.hostname;
-  return "https://" + domain + req.path;
+
+  return proto + "://" + domain + req.path;
 }
 
 // Create an Error object with the provided message and a custom attribute that remembers the

--- a/src/content.js
+++ b/src/content.js
@@ -104,6 +104,7 @@ function postprocess(presented_url, content_doc, callback) {
 
     var output_doc = {
       envelope: content_doc.envelope,
+      assets: content_doc.assets,
       results: output[0],
       layout: output[1]
     };

--- a/src/content.js
+++ b/src/content.js
@@ -142,8 +142,8 @@ function related(content_doc, callback) {
               var
                 doc = JSON.parse(body),
                 u = doc['presented-url'],
-                domain = config.presented_url_domain(),
-                proto = config.presented_url_proto();
+                domain = config.public_url_domain(),
+                proto = config.public_url_proto();
 
               if (domain || proto) {
                 var parsed = url.parse(u);

--- a/test/config.js
+++ b/test/config.js
@@ -10,6 +10,7 @@ describe("config", function () {
       MAPPING_SERVICE_URL: "https://mapping",
       CONTENT_SERVICE_URL: "https://content",
       LAYOUT_SERVICE_URL: "https://layout",
+      PRESENTED_URL_PROTO: "http",
       PRESENTED_URL_DOMAIN: "deconst.horse",
       PRESENTER_LOG_LEVEL: "debug"
     });
@@ -17,6 +18,7 @@ describe("config", function () {
     expect(config.mapping_service_url()).to.equal("https://mapping");
     expect(config.content_service_url()).to.equal("https://content");
     expect(config.layout_service_url()).to.equal("https://layout");
+    expect(config.presented_url_proto()).to.equal("http");
     expect(config.presented_url_domain()).to.equal("deconst.horse");
     expect(config.log_level()).to.equal("debug");
   });

--- a/test/config.js
+++ b/test/config.js
@@ -12,6 +12,8 @@ describe("config", function () {
       LAYOUT_SERVICE_URL: "https://layout",
       PRESENTED_URL_PROTO: "http",
       PRESENTED_URL_DOMAIN: "deconst.horse",
+      PUBLIC_URL_PROTO: "https",
+      PUBLIC_URL_DOMAIN: "localhost",
       PRESENTER_LOG_LEVEL: "debug"
     });
 
@@ -20,6 +22,8 @@ describe("config", function () {
     expect(config.layout_service_url()).to.equal("https://layout");
     expect(config.presented_url_proto()).to.equal("http");
     expect(config.presented_url_domain()).to.equal("deconst.horse");
+    expect(config.public_url_proto()).to.equal("https");
+    expect(config.public_url_domain()).to.equal("localhost");
     expect(config.log_level()).to.equal("debug");
   });
 

--- a/test/content.js
+++ b/test/content.js
@@ -2,10 +2,11 @@
 
 var config = require("../src/config");
 
-settings = {
+var settings = {
   MAPPING_SERVICE_URL: "http://mapping",
   CONTENT_SERVICE_URL: "http://content",
   LAYOUT_SERVICE_URL: "http://layout",
+  PRESENTED_URL_PROTO: "https",
   PRESENTED_URL_DOMAIN: "deconst.horse",
   PRESENTER_LOG_LEVEL: process.env.PRESENTER_LOG_LEVEL
 };

--- a/test/content.js
+++ b/test/content.js
@@ -48,7 +48,7 @@ describe("/*", function () {
       .expect("Rendered the page content with a layout", done);
   });
 
-  it("Collects presented URLs for related content", function (done) {
+  it("collects presented URLs for related content", function (done) {
     var mapping = nock("http://mapping")
       .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
       .reply(200, { "content-id": "https://github.com/deconst/fake" })
@@ -58,6 +58,43 @@ describe("/*", function () {
       .reply(200, { "presented-url": "https://deconst.horse/two" })
       .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fthree")
       .reply(200, { "presented-url": "https://deconst.horse/three" });
+
+    var content = nock("http://content")
+      .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
+      .reply(200, {
+        assets: [],
+        envelope: { body: "the page content" },
+        results: { sample: [
+            { contentID: "https://github.com/deconst/fake/one" },
+            { contentID: "https://github.com/deconst/fake/two" },
+            { contentID: "https://github.com/deconst/fake/three" }
+        ] }
+      });
+
+    var layout = nock("http://layout")
+      .get("/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/default")
+      .reply(200, "URLs: {{#each results.sample}}<{{url}}>{{/each}}");
+
+    var rendered = "URLs: <https://deconst.horse/one>" +
+      "<https://deconst.horse/two><https://deconst.horse/three>";
+
+    request(server.create())
+      .get("/foo/bar/baz")
+      .expect(200)
+      .expect("Content-Type", /html/)
+      .expect(rendered, done);
+  });
+
+  it("transforms related content URLs with a presented domain and protocol", function (done) {
+    var mapping = nock("http://mapping")
+      .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
+      .reply(200, { "content-id": "https://github.com/deconst/fake" })
+      .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fone")
+      .reply(200, { "presented-url": "http://other.wtf/one" })
+      .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Ftwo")
+      .reply(200, { "presented-url": "http://other.wtf/two" })
+      .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fthree")
+      .reply(200, { "presented-url": "http://other.wtf/three" });
 
     var content = nock("http://content")
       .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")

--- a/test/content.js
+++ b/test/content.js
@@ -86,15 +86,26 @@ describe("/*", function () {
   });
 
   it("transforms related content URLs with a presented domain and protocol", function (done) {
+    config.configure({
+      MAPPING_SERVICE_URL: "http://mapping",
+      CONTENT_SERVICE_URL: "http://content",
+      LAYOUT_SERVICE_URL: "http://layout",
+      PRESENTED_URL_PROTO: "https",
+      PRESENTED_URL_DOMAIN: "deconst.horse",
+      PUBLIC_URL_PROTO: "http",
+      PUBLIC_URL_DOMAIN: "localhost",
+      PRESENTER_LOG_LEVEL: process.env.PRESENTER_LOG_LEVEL
+    });
+
     var mapping = nock("http://mapping")
       .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
       .reply(200, { "content-id": "https://github.com/deconst/fake" })
       .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fone")
-      .reply(200, { "presented-url": "http://other.wtf/one" })
+      .reply(200, { "presented-url": "https://other.wtf/one" })
       .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Ftwo")
-      .reply(200, { "presented-url": "http://other.wtf/two" })
+      .reply(200, { "presented-url": "https://other.wtf/two" })
       .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fthree")
-      .reply(200, { "presented-url": "http://other.wtf/three" });
+      .reply(200, { "presented-url": "https://other.wtf/three" });
 
     var content = nock("http://content")
       .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
@@ -112,8 +123,8 @@ describe("/*", function () {
       .get("/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/default")
       .reply(200, "URLs: {{#each results.sample}}<{{url}}>{{/each}}");
 
-    var rendered = "URLs: <https://deconst.horse/one>" +
-      "<https://deconst.horse/two><https://deconst.horse/three>";
+    var rendered = "URLs: <http://localhost/one>" +
+      "<http://localhost/two><http://localhost/three>";
 
     request(server.create())
       .get("/foo/bar/baz")

--- a/test/content.js
+++ b/test/content.js
@@ -6,7 +6,8 @@ settings = {
   MAPPING_SERVICE_URL: "http://mapping",
   CONTENT_SERVICE_URL: "http://content",
   LAYOUT_SERVICE_URL: "http://layout",
-  PRESENTED_URL_DOMAIN: "deconst.horse"
+  PRESENTED_URL_DOMAIN: "deconst.horse",
+  PRESENTER_LOG_LEVEL: process.env.PRESENTER_LOG_LEVEL
 };
 
 config.configure(settings);

--- a/test/content.js
+++ b/test/content.js
@@ -45,4 +45,42 @@ describe("/*", function () {
       .expect("Content-Type", /html/)
       .expect("Rendered the page content with a layout", done);
   });
+
+  it("Collects presented URLs for related content", function (done) {
+    var mapping = nock("http://mapping")
+      .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
+      .reply(200, { "content-id": "https://github.com/deconst/fake" })
+      .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fone")
+      .reply(200, { "presented-url": "https://deconst.horse/one" })
+      .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Ftwo")
+      .reply(200, { "presented-url": "https://deconst.horse/two" })
+      .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fthree")
+      .reply(200, { "presented-url": "https://deconst.horse/three" });
+
+    var content = nock("http://content")
+      .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
+      .reply(200, {
+        assets: [],
+        envelope: { body: "the page content" },
+        results: { sample: [
+            { contentID: "https://github.com/deconst/fake/one" },
+            { contentID: "https://github.com/deconst/fake/two" },
+            { contentID: "https://github.com/deconst/fake/three" }
+        ] }
+      });
+
+    var layout = nock("http://layout")
+      .get("/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/default")
+      .reply(200, "URLs: {{#each results.sample}}<{{url}}>{{/each}}");
+
+    var rendered = "URLs: <https://deconst.horse/one>" +
+      "<https://deconst.horse/two><https://deconst.horse/three>";
+
+    request(server.create())
+      .get("/foo/bar/baz")
+      .expect(200)
+      .expect("Content-Type", /html/)
+      .expect(rendered, done);
+  });
+
 });


### PR DESCRIPTION
If related document results are present in a result document, discover the presented URL that's mapped to the content ID of each. This is what will let us actually link to the related content that we've discovered.

Part of deconst/deconst-docs#41.
#### Remaining Work
- [x] Override presented URL scheme in addition to domain.
- [x] Respect presented URL domain and scheme in injected `url` properties.
- [x] Test locally against the latest mapping service.
