### PR TITLE
Stack on 404

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -76,11 +76,13 @@ function mapping(presented, callback) {
 // Call the content service to acquire the document containing the metadata envelope and any
 // associated attributes at this content ID.
 function content(content_obj, callback) {
-  var content_url;
+  var content_url, content_desc;
   if (content_obj["proxy-to"]) {
     content_url = content_obj["proxy-to"];
+    content_desc = "proxy target [" + content_url + "]";
   } else if (content_obj["content-id"]) {
     content_url = urljoin(config.content_service_url(), 'content', encodeURIComponent(content_obj["content-id"]));
+    content_desc = "content ID [" + content_obj["content-id"] + "]";
   } else {
     callback(content_error(content_obj, "content [1]"), {});
   }
@@ -93,7 +95,7 @@ function content(content_obj, callback) {
     }
 
     if (res.statusCode !== 200) {
-      callback(response_error(res, "No content found for content ID [" + content_id + "]"));
+      callback(response_error(res, "No content found for " + content_desc));
       return;
     }
 

--- a/test/content.js
+++ b/test/content.js
@@ -81,7 +81,7 @@ describe("/*", function () {
       .get("/foo/bar/baz")
       .expect(404)
       .expect("The 404 page", done);
-  })
+  });
 
   it("collects presented URLs for related content", function (done) {
     var mapping = nock("http://mapping")

--- a/test/content.js
+++ b/test/content.js
@@ -64,6 +64,25 @@ describe("/*", function () {
     .expect("static content", done);
   });
 
+  it("returns a 404 when the content ID cannot be found", function (done) {
+    var mapping = nock("http://mapping")
+      .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
+      .reply(200, { "content-id": "https://github.com/deconst/fake" });
+
+    var content = nock("http://content")
+      .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
+      .reply(404);
+
+    var layout = nock("http://layout")
+      .get("/error/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/404")
+      .reply(200, "The 404 page");
+
+    request(server.create())
+      .get("/foo/bar/baz")
+      .expect(404)
+      .expect("The 404 page", done);
+  })
+
   it("collects presented URLs for related content", function (done) {
     var mapping = nock("http://mapping")
       .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")


### PR DESCRIPTION
This fixes a stack trace seen when an unknown content ID is encountered:

```
ReferenceError: content_id is not defined
    at Request._callback (/usr/src/app/src/content.js:96:74)
    at Request.self.callback (/usr/src/app/node_modules/request/request.js:344:22)
    at Request.emit (events.js:110:17)
    at Request.<anonymous> (/usr/src/app/node_modules/request/request.js:1239:14)
    at Request.emit (events.js:129:20)
    at IncomingMessage.<anonymous> (/usr/src/app/node_modules/request/request.js:1187:12)
    at IncomingMessage.emit (events.js:129:20)
    at _stream_readable.js:908:16
    at process._tickCallback (node.js:355:11)
```
