### PR TITLE
Pipe proxied responses directly

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -88,7 +88,7 @@ function content(target, callback) {
         logger.warn("Status code [" + res.statusCode +
           "] received from upstream service [" + proxy_url + "].");
       }
-    })
+    });
 
     var content_doc = {
       "proxy-to": true,

--- a/test/content.js
+++ b/test/content.js
@@ -76,17 +76,52 @@ describe("/*", function () {
 
     it("handles proxied content", function (done) {
       var mapping = nock("http://mapping")
-      .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fstatic")
-      .reply(200, { "proxy-to": "https://deconst.horse/static" });
+        .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fstatic")
+        .reply(200, { "proxy-to": "https://deconst.horse/static" });
 
       var content = nock("https://deconst.horse")
-      .get("/static")
-      .reply(200, "static content");
+        .get("/static")
+        .reply(200, "static content");
 
       request(server.create())
-      .get("/foo/bar/static")
-      .expect(200)
-      .expect("static content", done);
+        .get("/foo/bar/static")
+        .expect(200)
+        .expect("static content", done);
+    });
+
+    it("preserves headers from the upstream service", function (done) {
+      var mapping = nock("http://mapping")
+        .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fstatic")
+        .reply(200, { "proxy-to": "https://upstream.horse/service" });
+
+      var content = nock("https://upstream.horse")
+        .get("/service")
+        .reply(200, "static content", {
+          "Content-Type": "text/plain",
+          "X-Some-Header": "neeeeigh"
+        });
+
+      request(server.create())
+        .get("/foo/bar/static")
+        .expect(200)
+        .expect("Content-Type", "text/plain")
+        .expect("X-Some-Header", "neeeeigh")
+        .expect("static content", done);
+    });
+
+    it("preserves response status from the upstream service", function (done) {
+      var mapping = nock("http://mapping")
+        .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fstatic")
+        .reply(200, { "proxy-to": "https://upstream.horse/service" });
+
+      var content = nock("https://upstream.horse")
+        .get("/service")
+        .reply(409, "NOPE");
+
+      request(server.create())
+        .get("/foo/bar/static")
+        .expect(409)
+        .expect("NOPE", done);
     });
 
   });

--- a/test/content.js
+++ b/test/content.js
@@ -25,149 +25,161 @@ describe("/*", function () {
     config.configure(settings);
   });
 
-  it("assembles a page", function (done) {
-    var mapping = nock("http://mapping")
-      .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
-      .reply(200, { "content-id": "https://github.com/deconst/fake" });
+  describe("assembly", function () {
 
-    var content = nock("http://content")
-      .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
-      .reply(200, {
-        assets: [],
-        envelope: { body: "the page content" },
-        "content-id": true
-      });
+    it("assembles a page", function (done) {
+      var mapping = nock("http://mapping")
+        .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
+        .reply(200, { "content-id": "https://github.com/deconst/fake" });
 
-    var layout = nock("http://layout")
-      .get("/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/default")
-      .reply(200, "Rendered {{{ envelope.body }}} with a layout");
+      var content = nock("http://content")
+        .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
+        .reply(200, {
+          assets: [],
+          envelope: { body: "the page content" },
+          "content-id": true
+        });
 
-    request(server.create())
-      .get("/foo/bar/baz")
-      .expect(200)
-      .expect("Content-Type", /html/)
-      .expect("Rendered the page content with a layout", done);
-  });
+      var layout = nock("http://layout")
+        .get("/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/default")
+        .reply(200, "Rendered {{{ envelope.body }}} with a layout");
 
-  it("handles static content", function (done) {
-    var mapping = nock("http://mapping")
-    .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fstatic")
-    .reply(200, { "proxy-to": "https://deconst.horse/static" });
-
-    var content = nock("https://deconst.horse")
-    .get("/static")
-    .reply(200, "static content");
-
-    request(server.create())
-    .get("/foo/bar/static")
-    .expect(200)
-    .expect("static content", done);
-  });
-
-  it("returns a 404 when the content ID cannot be found", function (done) {
-    var mapping = nock("http://mapping")
-      .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
-      .reply(200, { "content-id": "https://github.com/deconst/fake" });
-
-    var content = nock("http://content")
-      .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
-      .reply(404);
-
-    var layout = nock("http://layout")
-      .get("/error/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/404")
-      .reply(200, "The 404 page");
-
-    request(server.create())
-      .get("/foo/bar/baz")
-      .expect(404)
-      .expect("The 404 page", done);
-  });
-
-  it("collects presented URLs for related content", function (done) {
-    var mapping = nock("http://mapping")
-      .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
-      .reply(200, { "content-id": "https://github.com/deconst/fake" })
-      .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fone")
-      .reply(200, { "presented-url": "https://deconst.horse/one" })
-      .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Ftwo")
-      .reply(200, { "presented-url": "https://deconst.horse/two" })
-      .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fthree")
-      .reply(200, { "presented-url": "https://deconst.horse/three" });
-
-    var content = nock("http://content")
-      .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
-      .reply(200, {
-        assets: [],
-        envelope: { body: "the page content" },
-        results: { sample: [
-            { contentID: "https://github.com/deconst/fake/one" },
-            { contentID: "https://github.com/deconst/fake/two" },
-            { contentID: "https://github.com/deconst/fake/three" }
-        ] },
-        "content-id": true
-      });
-
-    var layout = nock("http://layout")
-      .get("/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/default")
-      .reply(200, "URLs: {{#each results.sample}}<{{url}}>{{/each}}");
-
-    var rendered = "URLs: <https://deconst.horse/one>" +
-      "<https://deconst.horse/two><https://deconst.horse/three>";
-
-    request(server.create())
-      .get("/foo/bar/baz")
-      .expect(200)
-      .expect("Content-Type", /html/)
-      .expect(rendered, done);
-  });
-
-  it("transforms related content URLs with a presented domain and protocol", function (done) {
-    config.configure({
-      MAPPING_SERVICE_URL: "http://mapping",
-      CONTENT_SERVICE_URL: "http://content",
-      LAYOUT_SERVICE_URL: "http://layout",
-      PRESENTED_URL_PROTO: "https",
-      PRESENTED_URL_DOMAIN: "deconst.horse",
-      PUBLIC_URL_PROTO: "http",
-      PUBLIC_URL_DOMAIN: "localhost",
-      PRESENTER_LOG_LEVEL: process.env.PRESENTER_LOG_LEVEL
+      request(server.create())
+        .get("/foo/bar/baz")
+        .expect(200)
+        .expect("Content-Type", /html/)
+        .expect("Rendered the page content with a layout", done);
     });
 
-    var mapping = nock("http://mapping")
-      .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
-      .reply(200, { "content-id": "https://github.com/deconst/fake" })
-      .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fone")
-      .reply(200, { "presented-url": "https://other.wtf/one" })
-      .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Ftwo")
-      .reply(200, { "presented-url": "https://other.wtf/two" })
-      .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fthree")
-      .reply(200, { "presented-url": "https://other.wtf/three" });
+    it("returns a 404 when the content ID cannot be found", function (done) {
+      var mapping = nock("http://mapping")
+        .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
+        .reply(200, { "content-id": "https://github.com/deconst/fake" });
 
-    var content = nock("http://content")
-      .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
-      .reply(200, {
-        assets: [],
-        envelope: { body: "the page content" },
-        results: { sample: [
-            { contentID: "https://github.com/deconst/fake/one" },
-            { contentID: "https://github.com/deconst/fake/two" },
-            { contentID: "https://github.com/deconst/fake/three" }
-        ] },
-        "content-id": true
+      var content = nock("http://content")
+        .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
+        .reply(404);
+
+      var layout = nock("http://layout")
+        .get("/error/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/404")
+        .reply(200, "The 404 page");
+
+      request(server.create())
+        .get("/foo/bar/baz")
+        .expect(404)
+        .expect("The 404 page", done);
+    });
+
+  });
+
+  describe("proxied services", function () {
+
+    it("handles proxied content", function (done) {
+      var mapping = nock("http://mapping")
+      .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fstatic")
+      .reply(200, { "proxy-to": "https://deconst.horse/static" });
+
+      var content = nock("https://deconst.horse")
+      .get("/static")
+      .reply(200, "static content");
+
+      request(server.create())
+      .get("/foo/bar/static")
+      .expect(200)
+      .expect("static content", done);
+    });
+
+  });
+
+  describe("related content", function () {
+
+    it("collects presented URLs for related content", function (done) {
+      var mapping = nock("http://mapping")
+        .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
+        .reply(200, { "content-id": "https://github.com/deconst/fake" })
+        .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fone")
+        .reply(200, { "presented-url": "https://deconst.horse/one" })
+        .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Ftwo")
+        .reply(200, { "presented-url": "https://deconst.horse/two" })
+        .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fthree")
+        .reply(200, { "presented-url": "https://deconst.horse/three" });
+
+      var content = nock("http://content")
+        .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
+        .reply(200, {
+          assets: [],
+          envelope: { body: "the page content" },
+          results: { sample: [
+              { contentID: "https://github.com/deconst/fake/one" },
+              { contentID: "https://github.com/deconst/fake/two" },
+              { contentID: "https://github.com/deconst/fake/three" }
+          ] },
+          "content-id": true
+        });
+
+      var layout = nock("http://layout")
+        .get("/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/default")
+        .reply(200, "URLs: {{#each results.sample}}<{{url}}>{{/each}}");
+
+      var rendered = "URLs: <https://deconst.horse/one>" +
+        "<https://deconst.horse/two><https://deconst.horse/three>";
+
+      request(server.create())
+        .get("/foo/bar/baz")
+        .expect(200)
+        .expect("Content-Type", /html/)
+        .expect(rendered, done);
+    });
+
+    it("transforms related content URLs with a presented domain and protocol", function (done) {
+      config.configure({
+        MAPPING_SERVICE_URL: "http://mapping",
+        CONTENT_SERVICE_URL: "http://content",
+        LAYOUT_SERVICE_URL: "http://layout",
+        PRESENTED_URL_PROTO: "https",
+        PRESENTED_URL_DOMAIN: "deconst.horse",
+        PUBLIC_URL_PROTO: "http",
+        PUBLIC_URL_DOMAIN: "localhost",
+        PRESENTER_LOG_LEVEL: process.env.PRESENTER_LOG_LEVEL
       });
 
-    var layout = nock("http://layout")
-      .get("/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/default")
-      .reply(200, "URLs: {{#each results.sample}}<{{url}}>{{/each}}");
+      var mapping = nock("http://mapping")
+        .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
+        .reply(200, { "content-id": "https://github.com/deconst/fake" })
+        .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fone")
+        .reply(200, { "presented-url": "https://other.wtf/one" })
+        .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Ftwo")
+        .reply(200, { "presented-url": "https://other.wtf/two" })
+        .get("/url/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fthree")
+        .reply(200, { "presented-url": "https://other.wtf/three" });
 
-    var rendered = "URLs: <http://localhost/one>" +
-      "<http://localhost/two><http://localhost/three>";
+      var content = nock("http://content")
+        .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
+        .reply(200, {
+          assets: [],
+          envelope: { body: "the page content" },
+          results: { sample: [
+              { contentID: "https://github.com/deconst/fake/one" },
+              { contentID: "https://github.com/deconst/fake/two" },
+              { contentID: "https://github.com/deconst/fake/three" }
+          ] },
+          "content-id": true
+        });
 
-    request(server.create())
-      .get("/foo/bar/baz")
-      .expect(200)
-      .expect("Content-Type", /html/)
-      .expect(rendered, done);
+      var layout = nock("http://layout")
+        .get("/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/default")
+        .reply(200, "URLs: {{#each results.sample}}<{{url}}>{{/each}}");
+
+      var rendered = "URLs: <http://localhost/one>" +
+        "<http://localhost/two><http://localhost/three>";
+
+      request(server.create())
+        .get("/foo/bar/baz")
+        .expect(200)
+        .expect("Content-Type", /html/)
+        .expect(rendered, done);
+    });
+
   });
 
 });


### PR DESCRIPTION
If the mapping service indicates that a request should be proxied to an external service, pipe the response object back directly, rather than storing the body and creating a new response. This ensures that all headers and status codes are passed to the client directly, as well as being more efficient.

Addresses deconst/deconst-docs#77.
