### PR TITLE
Date formatting helper for Handlebars

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express": "4.12.3",
     "handlebars": "3.0.0",
     "lodash": "^3.8.0",
+    "moment": "^2.10.3",
     "request": "2.53.0",
     "url-join": "0.0.1",
     "winston": "^0.9.0"

--- a/src/content.js
+++ b/src/content.js
@@ -8,7 +8,8 @@ var
   handlebars = require('handlebars'),
   _ = require('lodash'),
   config = require('./config'),
-  logger = require('./logging').logger;
+  logger = require('./logging').logger,
+  helpers = require('./helpers');
 
 var page500 = "<!DOCTYPE html>" +
   "<html>" +
@@ -21,6 +22,8 @@ var page500 = "<!DOCTYPE html>" +
     "<p>It looks like you asked for a page that we don't have!</p>" +
   "</body>" +
   "</html>";
+
+helpers.register();
 
 // Derive the presented URL for a specific request, honoring the presented_url_domain and
 // presented_url_proto settings if provided.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,13 @@
+// Handlebars helpers for use in templates.
+
+var
+  handlebars = require('handlebars'),
+  moment = require('moment');
+
+var formatDateHelper = function (date, formatString) {
+  return moment(Date.parse(date)).format(formatString);
+};
+
+exports.register = function () {
+  handlebars.registerHelper('formatDate', formatDateHelper);
+};

--- a/test/content.js
+++ b/test/content.js
@@ -70,6 +70,33 @@ describe("/*", function () {
         .expect("The 404 page", done);
     });
 
+    it("allows templates to use handlebars helpers", function (done) {
+      var mapping = nock("http://mapping")
+        .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
+        .reply(200, { "content-id": "https://github.com/deconst/fake" });
+
+      var content = nock("http://content")
+        .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
+        .reply(200, {
+          assets: [],
+          envelope: {
+            body: "success",
+            publish_date: "Fri, 15 May 2015 18:32:45 GMT"
+          },
+          "content-id": true
+        });
+
+      var layout = nock("http://layout")
+        .get("/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/default")
+        .reply(200, "Body [{{{ envelope.body }}}] Date [{{formatDate envelope.publish_date 'YYYY-MM-DD' }}]");
+
+      request(server.create())
+        .get("/foo/bar/baz")
+        .expect(200)
+        .expect("Content-Type", /html/)
+        .expect("Body [success] Date [2015-05-15]", done);
+    });
+
   });
 
   describe("proxied services", function () {


### PR DESCRIPTION
Include a Handlebars helper that can format metadata envelope dates in arbitrary ways.

Addresses deconst/deconst-docs#75.
