### PR TITLE
Null layout

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -11,6 +11,7 @@ var
   logger = require('./logging').logger,
   helpers = require('./helpers');
 
+// The page to render if an error page layout isn't defined.
 var page500 = "<!DOCTYPE html>" +
   "<html>" +
   "<head>" +
@@ -22,6 +23,9 @@ var page500 = "<!DOCTYPE html>" +
     "<p>It looks like you asked for a page that we don't have!</p>" +
   "</body>" +
   "</html>";
+
+// The layout to use if no layout_key is requested by the metadata envelope.
+var nullLayout = handlebars.compile("{{{ envelope.body }}}");
 
 helpers.register();
 
@@ -229,8 +233,15 @@ function related(content_doc, callback) {
 
 // Call the layout service to decide which layout to apply to this presented URL.
 function layout(presented_url, content_doc, callback) {
+  var layout_key = content_doc.envelope.layout_key;
+
+  if (!layout_key) {
+    logger.debug("No layout key requested. Using null layout.");
+
+    return callback(null, nullLayout);
+  }
+
   var
-    layout_key = content_doc.envelope.layout_key || "default",
     encoded_presented = encodeURIComponent(presented_url),
     layout_url = urljoin(config.layout_service_url(), encoded_presented, layout_key);
 

--- a/test/content.js
+++ b/test/content.js
@@ -51,6 +51,45 @@ describe("/*", function () {
         .expect("Rendered the page content with a layout", done);
     });
 
+    it("supports a null layout_key", function (done) {
+      var mapping = nock("http://mapping")
+        .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
+        .reply(200, { "content-id": "https://github.com/deconst/fake" });
+
+      var content = nock("http://content")
+        .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
+        .reply(200, {
+          assets: [],
+          envelope: { layout_key: null, body: "only this" }
+        });
+
+      request(server.create())
+        .get("/foo/bar/baz")
+        .expect(200)
+        .expect("Content-Type", /html/)
+        .expect("only this", done);
+    });
+
+    it("supports a missing layout_key", function (done) {
+      var mapping = nock("http://mapping")
+        .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
+        .reply(200, { "content-id": "https://github.com/deconst/fake" });
+
+      var content = nock("http://content")
+        .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
+        .reply(200, {
+          assets: [],
+          envelope: { body: "only this" },
+          "content-id": true
+        });
+
+      request(server.create())
+        .get("/foo/bar/baz")
+        .expect(200)
+        .expect("Content-Type", /html/)
+        .expect("only this", done);
+    });
+
     it("returns a 404 when the content ID cannot be found", function (done) {
       var mapping = nock("http://mapping")
         .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")

--- a/test/content.js
+++ b/test/content.js
@@ -36,8 +36,7 @@ describe("/*", function () {
         .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
         .reply(200, {
           assets: [],
-          envelope: { body: "the page content" },
-          "content-id": true
+          envelope: { layout_key: "default", body: "the page content" }
         });
 
       var layout = nock("http://layout")
@@ -119,10 +118,10 @@ describe("/*", function () {
         .reply(200, {
           assets: [],
           envelope: {
+            layout_key: "default",
             body: "success",
             publish_date: "Fri, 15 May 2015 18:32:45 GMT"
           },
-          "content-id": true
         });
 
       var layout = nock("http://layout")
@@ -209,7 +208,10 @@ describe("/*", function () {
         .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
         .reply(200, {
           assets: [],
-          envelope: { body: "the page content" },
+          envelope: {
+            layout_key: "default",
+            body: "the page content"
+          },
           results: { sample: [
               { contentID: "https://github.com/deconst/fake/one" },
               { contentID: "https://github.com/deconst/fake/two" },
@@ -258,7 +260,10 @@ describe("/*", function () {
         .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
         .reply(200, {
           assets: [],
-          envelope: { body: "the page content" },
+          envelope: {
+            layout_key: "default",
+            body: "the page content"
+          },
           results: { sample: [
               { contentID: "https://github.com/deconst/fake/one" },
               { contentID: "https://github.com/deconst/fake/two" },


### PR DESCRIPTION
Instead of defaulting to a layout with the special key "default", default to a static template that emits the envelope body unchanged.

This is necessary to support envelopes containing content like the RSS feed from deconst/deconst-docs#74.
