### PR TITLE
Set the content-type from the envelope

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -317,9 +317,13 @@ module.exports = function (req, res) {
       // Apply final transformations and additions to the content document before rendering.
       content_doc.presented_url = presented;
       content_doc.has_next_or_previous =
-      !!(content_doc.envelope.next || content_doc.envelope.previous);
+        !!(content_doc.envelope.next || content_doc.envelope.previous);
 
       logger.debug("Rendering final content document:", content_doc);
+
+      if (content_doc.envelope.content_type) {
+        res.set("Content-Type", content_doc.envelope.content_type);
+      }
 
       var html = content_doc.layout(content_doc);
 

--- a/test/content.js
+++ b/test/content.js
@@ -89,7 +89,7 @@ describe("/*", function () {
         .expect("only this", done);
     });
 
-    it.only("respects a content-type from the envelope", function (done) {
+    it("respects a content-type from the envelope", function (done) {
       var mapping = nock("http://mapping")
         .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
         .reply(200, { "content-id": "https://github.com/deconst/fake" });

--- a/test/content.js
+++ b/test/content.js
@@ -107,7 +107,7 @@ describe("/*", function () {
       request(server.create())
         .get("/foo/bar/baz")
         .expect(200)
-        .expect("Content-Type", "text/plain")
+        .expect("Content-Type", /text\/plain/)
         .expect("yup", done);
     });
 

--- a/test/content.js
+++ b/test/content.js
@@ -89,6 +89,28 @@ describe("/*", function () {
         .expect("only this", done);
     });
 
+    it.only("respects a content-type from the envelope", function (done) {
+      var mapping = nock("http://mapping")
+        .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
+        .reply(200, { "content-id": "https://github.com/deconst/fake" });
+
+      var content = nock("http://content")
+        .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
+        .reply(200, {
+          assets: [],
+          envelope: {
+            body: "yup",
+            content_type: "text/plain"
+          }
+        });
+
+      request(server.create())
+        .get("/foo/bar/baz")
+        .expect(200)
+        .expect("Content-Type", "text/plain")
+        .expect("yup", done);
+    });
+
     it("returns a 404 when the content ID cannot be found", function (done) {
       var mapping = nock("http://mapping")
         .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")


### PR DESCRIPTION
If a metadata envelope contains a `content_type` key, use it to populate the content type of the response.

This is useful for things like a templated RSS feed from deconst/deconst-docs#74.
