### PR TITLE
No error steamrolling

### DIFF
--- a/static/404.html
+++ b/static/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Rendered by Deconst</title>
+</head>
+<body>
+  <h1>Whoops</h1>
+  <p>It looks like you asked for a page that we don't have!</p>
+</body>
+</html>

--- a/static/500.html
+++ b/static/500.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Rendered by Deconst</title>
+</head>
+<body>
+  <h1>Whoops</h1>
+  <p>Something crazy happened while this page was being rendered.</p>
+</body>
+</html>

--- a/test/content.js
+++ b/test/content.js
@@ -148,6 +148,24 @@ describe("/*", function () {
         .expect(404, done);
     });
 
+    it("passes other failing status codes through", function (done) {
+      var mapping = nock("http://mapping")
+        .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
+        .reply(200, { "content-id": "https://github.com/deconst/fake" });
+
+      var content = nock("http://content")
+        .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
+        .reply(409);
+
+      var layout = nock("http://layout")
+        .get("/error/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/409")
+        .reply(404);
+
+      request(server.create())
+        .get("/foo/bar/baz")
+        .expect(409, done);
+    });
+
     it("allows templates to use handlebars helpers", function (done) {
       var mapping = nock("http://mapping")
         .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")

--- a/test/content.js
+++ b/test/content.js
@@ -130,6 +130,24 @@ describe("/*", function () {
         .expect("The 404 page", done);
     });
 
+    it("returns a 404 even when no 404 layout is found", function (done) {
+      var mapping = nock("http://mapping")
+        .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")
+        .reply(200, { "content-id": "https://github.com/deconst/fake" });
+
+      var content = nock("http://content")
+        .get("/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake")
+        .reply(404);
+
+      var layout = nock("http://layout")
+        .get("/error/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz/404")
+        .reply(404);
+
+      request(server.create())
+        .get("/foo/bar/baz")
+        .expect(404, done);
+    });
+
     it("allows templates to use handlebars helpers", function (done) {
       var mapping = nock("http://mapping")
         .get("/at/https%3A%2F%2Fdeconst.horse%2Ffoo%2Fbar%2Fbaz")


### PR DESCRIPTION
If an upstream service returns a 404 or another error response, but no error status is defined for that status code in the control repository, fall back to a hardcoded, static error page, and preserve the original status code.

This is the last part of deconst/presenter#38.
