### PR TITLE
Pleasantly bland styling for the error pages

### DIFF
--- a/static/404.html
+++ b/static/404.html
@@ -2,10 +2,14 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Rendered by Deconst</title>
+  <title>Page Not Found</title>
+  <style type="text/css">body,html{background:#ebebeb;color:#333;font-family:Arial,sans-serif;font-size:16px;height:100%;width:100%}#message{background:#FFF;border-radius:4px;-webkit-box-shadow:0 4px 8px rgba(0,0,0,.13);box-shadow:0 4px 8px rgba(0,0,0,.13);margin:10vh auto 0;max-width:450px;padding:40px;text-align:center}#message h1,#message p{margin-top:0;margin-bottom:1.2em}#footer{bottom:12px;color:#aaa;display:block;font-size:12px;left:12px;margin:0 auto;position:fixed}#footer a{color:#aaa}#footer a:active,#footer a:focus,#footer a:hover{color:#09f}</style>
 </head>
 <body>
-  <h1>Whoops</h1>
-  <p>It looks like you asked for a page that we don't have!</p>
+    <div id="message">
+        <h1>Page Not Found</h1>
+        <p>Sorry, the page you requested does not exist.</p>
+    </div>
+    <span id="footer">Powered by <a href="https://github.com/deconst/deconst">deconst</a></span>
 </body>
 </html>

--- a/static/500.html
+++ b/static/500.html
@@ -2,10 +2,14 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Rendered by Deconst</title>
+  <title>System Error</title>
+  <style type="text/css">body,html{background:#ebebeb;color:#333;font-family:Arial,sans-serif;font-size:16px;height:100%;width:100%}#message{background:#FFF;border-radius:4px;-webkit-box-shadow:0 4px 8px rgba(0,0,0,.13);box-shadow:0 4px 8px rgba(0,0,0,.13);margin:10vh auto 0;max-width:450px;padding:40px;text-align:center}#message h1,#message p{margin-top:0;margin-bottom:1.2em}#footer{bottom:12px;color:#aaa;display:block;font-size:12px;left:12px;margin:0 auto;position:fixed}#footer a{color:#aaa}#footer a:active,#footer a:focus,#footer a:hover{color:#09f}</style>
 </head>
 <body>
-  <h1>Whoops</h1>
-  <p>Something crazy happened while this page was being rendered.</p>
+    <div id="message">
+        <h1>System Error</h1>
+        <p>Sorry, a system error has prevented this page from being shown correctly.</p>
+    </div>
+    <span id="footer">Powered by <a href="https://github.com/deconst/deconst">deconst</a></span>
 </body>
 </html>


### PR DESCRIPTION
These templates should usually be provided by the control repo, but in the event that template isn't provided, our error pages should still look a little professional.
