### PR TITLE
use prefix to force root-relative ToC URLs

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -151,6 +151,14 @@ function globals(presentedUrl, contentDoc, callback) {
             return callback(null, {});
         }
 
+        // much shame
+        var relativeUrls = /href=("|')(..\/)?([^\/].*?)("|')/g;
+        output.envelope.body =
+            output.envelope.body.replace(
+                relativeUrls,
+                'href=$1' + contentDoc.prefix + '$3$4'
+            );
+
         return callback(null, {
             toc: output.envelope.body
         });


### PR DESCRIPTION
Our master ToC method was generating hrefs like `../cloud-intro`, which basically broke the whole thing. In order to work at all levels within the book, these links need to be root-relative. I'm using the prefix to determine this root-relative URL and replacing all the dot-relative URLs in the ToC with the root-relative one.

I'm not especially proud of this, but it needs to happen and it works.
