### PR TITLE
Crash on demand in non-production settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ presenter:
     PRESENTED_URL_PROTO:
     PRESENTED_URL_DOMAIN:
     PRESENTER_LOG_LEVEL:
+    PRESENTER_DIAGNOSTICS:
   ports:
   - "80:8080"
   volumes:

--- a/env.example
+++ b/env.example
@@ -29,3 +29,6 @@ export PRESENTED_URL_DOMAIN=
 # warn
 # error
 export PRESENTER_LOG_LEVEL=info
+
+# Set to a non-empty value to enable diagnostic behavior, like triggering crashes at will.
+export PRESENTER_DIAGNOSTICS="true"

--- a/src/config.js
+++ b/src/config.js
@@ -56,6 +56,11 @@ var configuration = {
         normalize: normalize_lower,
         def: "info",
         required: false
+    },
+    presenter_diagnostics: {
+        env: "PRESENTER_DIAGNOSTICS",
+        description: "Enable diagnostic tooling within the presenter.",
+        required: false
     }
 };
 

--- a/src/routers/crash.js
+++ b/src/routers/crash.js
@@ -1,0 +1,8 @@
+// Crash the presenter process at will with an uncaught exception.
+//
+// This is useful for debugging the resilience of the system, collection of stacktraces, and so
+// forth. It should only be installed in non-production environments.
+
+module.exports = function (req, res) {
+    throw new Error("AHHHHHHHHHHHH MOTHERLAND");
+};

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -2,8 +2,10 @@
 
 var version = require('./version');
 var content = require('./content');
+var crash = require('./crash');
 var RequestHelper = require('../helpers/request');
 var ResponseHelper = require('../helpers/response');
+var config = require('../config');
 
 exports.install = function (app) {
     app.use(function (req, res, next) {
@@ -12,6 +14,10 @@ exports.install = function (app) {
 
         next();
     });
+
+    if(config.presenter_diagnostics()) {
+        app.get('/crash', crash);
+    }
 
     app.get('/version', version);
     app.get('/*', content);


### PR DESCRIPTION
This is mostly useful for being able to reliably replicate an abnormal container exit status to test the resilience of the infrastructure in _non-production_ environments.

Weirdly, express seems to catch the exceptions fine in my local tests, even though the container has been going down in production on each uncaught exception. It does dump the full stack to the response, which isn't the friendliest thing it could do.
