### PR TITLE
Semistandard

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,11 +9,10 @@ var config = require('./src/config');
 
 config.configure(process.env);
 
-var
-  logger = require('./src/server/logging').logger,
+var logger = require('./src/server/logging').logger,
   app = require('./src/server').create();
 
-var server = app.listen(8080, function() {
+var server = app.listen(8080, function () {
   var host = server.address().address;
   var port = server.address().port;
 

--- a/app.js
+++ b/app.js
@@ -9,8 +9,8 @@ var config = require('./src/config');
 
 config.configure(process.env);
 
-var logger = require('./src/server/logging').logger,
-  app = require('./src/server').create();
+var logger = require('./src/server/logging').logger;
+var app = require('./src/server').create();
 
 var server = app.listen(8080, function () {
   var host = server.address().address;

--- a/package.json
+++ b/package.json
@@ -8,9 +8,8 @@
     "url": "https://github.com/deconst/presenter.git"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha",
-    "docker-build": "docker build -t presenter .",
-    "docker-run": "sh -c \"docker run -it --rm --name presenter-running -p 80:8080 -e MAPPING_SERVICE_URL=$MAPPING_SERVICE_URL -e CONTENT_SERVICE_URL=$CONTENT_SERVICE_URL presenter\"",
+    "test": "mocha && semistandard",
+    "format": "semistandard --format",
     "start": "node app.js"
   },
   "author": "Jon Perritt <jon.perritt@rackspace.com>",
@@ -35,6 +34,7 @@
     "chai": "^2.3.0",
     "mocha": "^2.2.4",
     "nock": "^1.7.1",
+    "semistandard": "^7.0.2",
     "supertest": "^0.15.0"
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,78 +1,78 @@
 // Handle application configuration.
 
 var configuration = {
-    control_repo_path: {
-        env: "CONTROL_REPO_PATH",
-        description: "Filesystem path to the control repo",
-        required: true
-    },
-    control_content_file: {
-        env: "CONTROL_CONTENT_FILE",
-        description: "basename of the control repo's content config file",
-        def: 'content.json',
-        required: true
-    },
-    control_rewrites_file: {
-        env: "CONTROL_REWRITES_FILE",
-        description: "basename of the control repo's rewrites config file",
-        def: 'rewrites.json',
-        required: false
-    },
-    control_routes_file: {
-        env: "CONTROL_ROUTES_FILE",
-        description: "basename of the control repo's routes config file",
-        def: 'routes.json',
-        required: true
-    },
-    content_service_url: {
-        env: "CONTENT_SERVICE_URL",
-        description: "URL of the content service",
-        normalize: normalize_url,
-        required: true
-    },
-    presented_url_proto: {
-        env: "PRESENTED_URL_PROTO",
-        description: "Override the protocol of presented URLs",
-        required: false
-    },
-    presented_url_domain: {
-        env: "PRESENTED_URL_DOMAIN",
-        description: "Override the domain of presented URLs",
-        required: false
-    },
-    public_url_proto: {
-        env: "PUBLIC_URL_PROTO",
-        description: "Override the protocol of outgoing URLs",
-        required: false
-    },
-    public_url_domain: {
-        env: "PUBLIC_URL_DOMAIN",
-        description: "Override the domain of outgoing URLs",
-        required: false
-    },
-    log_level: {
-        env: "PRESENTER_LOG_LEVEL",
-        description: "Log level for the presenter.",
-        normalize: normalize_lower,
-        def: "info",
-        required: false
-    },
-    log_colorize: {
-        env: "PRESENTER_LOG_COLOR",
-        description: "Set to 'true' to enable colorized log output.",
-        normalize: normalize_bool,
-        def: "false",
-        required: false,
-    },
-    presenter_diagnostics: {
-        env: "PRESENTER_DIAGNOSTICS",
-        description: "Enable diagnostic tooling within the presenter.",
-        required: false
-    }
+  control_repo_path: {
+    env: 'CONTROL_REPO_PATH',
+    description: 'Filesystem path to the control repo',
+    required: true
+  },
+  control_content_file: {
+    env: 'CONTROL_CONTENT_FILE',
+    description: "basename of the control repo's content config file",
+    def: 'content.json',
+    required: true
+  },
+  control_rewrites_file: {
+    env: 'CONTROL_REWRITES_FILE',
+    description: "basename of the control repo's rewrites config file",
+    def: 'rewrites.json',
+    required: false
+  },
+  control_routes_file: {
+    env: 'CONTROL_ROUTES_FILE',
+    description: "basename of the control repo's routes config file",
+    def: 'routes.json',
+    required: true
+  },
+  content_service_url: {
+    env: 'CONTENT_SERVICE_URL',
+    description: 'URL of the content service',
+    normalize: normalize_url,
+    required: true
+  },
+  presented_url_proto: {
+    env: 'PRESENTED_URL_PROTO',
+    description: 'Override the protocol of presented URLs',
+    required: false
+  },
+  presented_url_domain: {
+    env: 'PRESENTED_URL_DOMAIN',
+    description: 'Override the domain of presented URLs',
+    required: false
+  },
+  public_url_proto: {
+    env: 'PUBLIC_URL_PROTO',
+    description: 'Override the protocol of outgoing URLs',
+    required: false
+  },
+  public_url_domain: {
+    env: 'PUBLIC_URL_DOMAIN',
+    description: 'Override the domain of outgoing URLs',
+    required: false
+  },
+  log_level: {
+    env: 'PRESENTER_LOG_LEVEL',
+    description: 'Log level for the presenter.',
+    normalize: normalize_lower,
+    def: 'info',
+    required: false
+  },
+  log_colorize: {
+    env: 'PRESENTER_LOG_COLOR',
+    description: "Set to 'true' to enable colorized log output.",
+    normalize: normalize_bool,
+    def: 'false',
+    required: false,
+  },
+  presenter_diagnostics: {
+    env: 'PRESENTER_DIAGNOSTICS',
+    description: 'Enable diagnostic tooling within the presenter.',
+    required: false
+  }
 };
 
 // Normalize a URL by ensuring that it ends with a trailing slash.
-function normalize_url(url) {
+function normalize_url (url) {
   if (url.slice(-1) === '/') {
     return url.slice(0, -1);
   }
@@ -80,24 +80,24 @@ function normalize_url(url) {
 }
 
 // Normalize a string by ensuring that it's lowercase.
-function normalize_lower(str) {
+function normalize_lower (str) {
   return str.toLowerCase();
 }
 
-function normalize_bool(str) {
-    var lower = str.toLowerCase();
-    if (lower === "true") {
-        return true;
-    }
-    if (lower === "false") {
-        return false;
-    }
+function normalize_bool (str) {
+  var lower = str.toLowerCase();
+  if (lower === 'true') {
+    return true;
+  }
+  if (lower === 'false') {
+    return false;
+  }
 
-    throw new Error("Invalid boolean setting: '" + str + "'");
+  throw new Error("Invalid boolean setting: '" + str + "'");
 }
 
 // Create a getter function for the named setting.
-function make_getter(setting_name) {
+function make_getter (setting_name) {
   return function () {
     return configuration[setting_name].value;
   };
@@ -129,22 +129,22 @@ exports.configure = function (env) {
   }
 
   if (missing.length !== 0) {
-    console.error("Required configuration values are missing!");
-    console.error("Please set the following environment variables:");
-    console.error("");
+    console.error('Required configuration values are missing!');
+    console.error('Please set the following environment variables:');
+    console.error('');
     missing.forEach(function (setting) {
-      console.error("  " + setting.env + ": " + setting.description);
+      console.error('  ' + setting.env + ': ' + setting.description);
     });
-    console.error("");
+    console.error('');
 
-    throw new Error("Inadequate configuration");
+    throw new Error('Inadequate configuration');
   }
 };
 
 exports.set = function (options) {
-    for(var name in options) {
-        configuration[normalize_lower(name)].value = options[name];
-    }
+  for (var name in options) {
+    configuration[normalize_lower(name)].value = options[name];
+  }
 };
 
 // Export "getter" functions with the same name as each configuration option.

--- a/src/config.js
+++ b/src/config.js
@@ -62,7 +62,7 @@ var configuration = {
     description: "Set to 'true' to enable colorized log output.",
     normalize: normalize_bool,
     def: 'false',
-    required: false,
+    required: false
   },
   presenter_diagnostics: {
     env: 'PRESENTER_DIAGNOSTICS',
@@ -112,7 +112,7 @@ exports.configure = function (env) {
     var setting = configuration[name];
     var value = env[setting.env];
 
-    if (! value && setting.def) {
+    if (!value && setting.def) {
       value = setting.def;
     }
 
@@ -123,7 +123,7 @@ exports.configure = function (env) {
     setting.value = value;
 
     // Missing or blank values from the environment are considered "unset."
-    if (! value && setting.required) {
+    if (!value && setting.required) {
       missing.push(setting);
     }
   }

--- a/src/helpers/context.js
+++ b/src/helpers/context.js
@@ -1,83 +1,82 @@
-var
-    logger = require('../server/logging').logger,
-    config = require('../config'),
-    TemplateService = require('../services/template');
+var logger = require('../server/logging').logger,
+  config = require('../config'),
+  TemplateService = require('../services/template');
 
-function Context(req, resp) {
-    this.request = req;
-    this.response = resp;
-    this.startTimestamp = Date.now();
+function Context (req, resp) {
+  this.request = req;
+  this.response = resp;
+  this.startTimestamp = Date.now();
 
-    this.contentId = null;
-    this.templatePath = null;
+  this.contentId = null;
+  this.templatePath = null;
 
-    this.contentReqDuration = null;
-    this.assetReqDuration = null;
-    this.templateRenderDuration = null;
+  this.contentReqDuration = null;
+  this.assetReqDuration = null;
+  this.templateRenderDuration = null;
 }
 
 Context.prototype._summarize = function (statusCode, message) {
-    var summary = {
-        statusCode: statusCode,
-        message: message,
-        requestURL: this.request.url,
-        totalReqDuration: Date.now() - this.startTimestamp
-    };
+  var summary = {
+    statusCode: statusCode,
+    message: message,
+    requestURL: this.request.url,
+    totalReqDuration: Date.now() - this.startTimestamp
+  };
 
-    if (this.contentId !== null) {
-        summary.contentID = this.contentId;
-    }
+  if (this.contentId !== null) {
+    summary.contentID = this.contentId;
+  }
 
-    if (this.templatePath !== null) {
-        summary.templatePath = this.templatePath;
-    }
+  if (this.templatePath !== null) {
+    summary.templatePath = this.templatePath;
+  }
 
-    if (this.contentReqDuration !== null) {
-        summary.contentReqDuration = this.contentReqDuration;
-    }
+  if (this.contentReqDuration !== null) {
+    summary.contentReqDuration = this.contentReqDuration;
+  }
 
-    if (this.templateRenderDuration !== null) {
-        summary.templateRenderDuration = this.templateRenderDuration;
-    }
+  if (this.templateRenderDuration !== null) {
+    summary.templateRenderDuration = this.templateRenderDuration;
+  }
 
-    return summary;
+  return summary;
 };
 
 Context.prototype.host = function () {
-    return config.presented_url_domain() || this.request.get('Host');
+  return config.presented_url_domain() || this.request.get('Host');
 };
 
 Context.prototype.protocol = function () {
-    return config.presented_url_proto() || this.request.protocol;
+  return config.presented_url_proto() || this.request.protocol;
 };
 
 Context.prototype.send = function (body) {
-    this.response.send(body);
-    logger.info(this._summarize(200, "Successful request"));
+  this.response.send(body);
+  logger.info(this._summarize(200, 'Successful request'));
 };
 
 Context.prototype.handleError = function (err) {
-    logger.debug(err);
-    var code = err.statusCode || 500;
-    var message = err.message;
-    if (err.statusCode && err.statusCode.toString() === "404") {
-        code = 404;
+  logger.debug(err);
+  var code = err.statusCode || 500;
+  var message = err.message;
+  if (err.statusCode && err.statusCode.toString() === '404') {
+    code = 404;
+  }
+
+  TemplateService.render(this, code.toString(), {}, function (err, responseBody) {
+    if (err) {
+      logger.error("I couldn't render an error template. I'm freaking out!", err);
+      responseBody = "Er, I was going to render an error template, but I couldn't.";
     }
 
-    TemplateService.render(this, code.toString(), {}, function (err, responseBody) {
-        if (err) {
-            logger.error("I couldn't render an error template. I'm freaking out!", err);
-            responseBody = "Er, I was going to render an error template, but I couldn't.";
-        }
+    this.response.status(code).send(responseBody);
 
-        this.response.status(code).send(responseBody);
-
-        if (code >= 500) {
-            logger.warn(this._summarize(code, "Internal error"));
-        } else {
-            logger.info(this._summarize(code, "Request error"));
-        }
-    }.bind(this));
+    if (code >= 500) {
+      logger.warn(this._summarize(code, 'Internal error'));
+    } else {
+      logger.info(this._summarize(code, 'Request error'));
+    }
+  }.bind(this));
 };
 
 module.exports = Context;

--- a/src/helpers/context.js
+++ b/src/helpers/context.js
@@ -1,6 +1,6 @@
-var logger = require('../server/logging').logger,
-  config = require('../config'),
-  TemplateService = require('../services/template');
+var logger = require('../server/logging').logger;
+var config = require('../config');
+var TemplateService = require('../services/template');
 
 function Context (req, resp) {
   this.request = req;
@@ -58,7 +58,6 @@ Context.prototype.send = function (body) {
 Context.prototype.handleError = function (err) {
   logger.debug(err);
   var code = err.statusCode || 500;
-  var message = err.message;
   if (err.statusCode && err.statusCode.toString() === '404') {
     code = 404;
   }

--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -1,128 +1,125 @@
 // Handler to assemble a specific piece of static content.
 
-var
-    fs = require('fs'),
-    path = require('path'),
-    request = require('request'),
-    url = require('url'),
-    urljoin = require('url-join'),
-    async = require('async'),
-    handlebars = require('handlebars'),
-    _ = require('lodash'),
-    config = require('../config'),
-    logger = require('../server/logging').logger,
-    Context = require('../helpers/context'),
-    TemplateService = require('../services/template'),
-    TemplateRoutingService = require('../services/template-routing'),
-    ContentService = require('../services/content'),
-    ContentRoutingService = require('../services/content/routing'),
-    ContentFilterService = require('../services/content/filter'),
-    UrlService = require('../services/url');
+var fs = require('fs'),
+  path = require('path'),
+  request = require('request'),
+  url = require('url'),
+  urljoin = require('url-join'),
+  async = require('async'),
+  handlebars = require('handlebars'),
+  _ = require('lodash'),
+  config = require('../config'),
+  logger = require('../server/logging').logger,
+  Context = require('../helpers/context'),
+  TemplateService = require('../services/template'),
+  TemplateRoutingService = require('../services/template-routing'),
+  ContentService = require('../services/content'),
+  ContentRoutingService = require('../services/content/routing'),
+  ContentFilterService = require('../services/content/filter'),
+  UrlService = require('../services/url');
 
 // Register content filters.
 
 ContentFilterService.add(function (input, next) {
-    var
-        context = input.context,
-        content = input.content;
+  var context = input.context,
+    content = input.content;
 
-    // Match nunjucks-like "{{ to('') }}" directives that are used to defer rendering of presented URLs
-    // until presenter-time.
-    var urlDirectiveRx = /\{\{\s*to\('([^']+)'\)\s*\}\}/g;
+  // Match nunjucks-like "{{ to('') }}" directives that are used to defer rendering of presented URLs
+  // until presenter-time.
+  var urlDirectiveRx = /\{\{\s*to\('([^']+)'\)\s*\}\}/g;
 
-    if (content.contentID && content.envelope) {
-        // Replace any "{{ to() }}" directives with the appropriate presented URL.
-        content.envelope.body = content.envelope.body.replace(
-            urlDirectiveRx,
-            function (match, contentID) {
-                return ContentRoutingService.getPresentedUrl(context, contentID);
-            }
-        );
-    }
+  if (content.contentID && content.envelope) {
+    // Replace any "{{ to() }}" directives with the appropriate presented URL.
+    content.envelope.body = content.envelope.body.replace(
+      urlDirectiveRx,
+      function (match, contentID) {
+        return ContentRoutingService.getPresentedUrl(context, contentID);
+      }
+    );
+  }
 
-    return next();
+  return next();
 });
 
 ContentFilterService.add(function (input, next) {
-    var
-        context = input.context,
-        content = input.content;
+  var context = input.context,
+    content = input.content;
 
-    // Locate the URLs for the content IDs of any next and previous links included in the
-    // document.
-    if (content.next && content.next.contentID && ! content.next.url) {
-        content.next.url = ContentRoutingService.getPresentedUrl(context, content.next.contentID);
-    }
+  // Locate the URLs for the content IDs of any next and previous links included in the
+  // document.
+  if (content.next && content.next.contentID && ! content.next.url) {
+    content.next.url = ContentRoutingService.getPresentedUrl(context, content.next.contentID);
+  }
 
-    if (content.previous && content.previous.contentID && ! content.previous.url) {
-        content.previous.url = ContentRoutingService.getPresentedUrl(context, content.previous.contentID);
-    }
+  if (content.previous && content.previous.contentID && ! content.previous.url) {
+    content.previous.url = ContentRoutingService.getPresentedUrl(context, content.previous.contentID);
+  }
 
-    return next();
+  return next();
 });
 
 module.exports = function (req, res) {
-    var context = new Context(req, res);
+  var context = new Context(req, res);
 
-    var contentId = ContentRoutingService.getContentId(context);
-    var prefix = ContentRoutingService.getContentPrefix(context);
-    var tocId = ContentRoutingService.getContentId(context,
-        UrlService.getSitePath(prefix + '_toc')
-    );
+  var contentId = ContentRoutingService.getContentId(context);
+  var prefix = ContentRoutingService.getContentPrefix(context);
+  var tocId = ContentRoutingService.getContentId(context,
+    UrlService.getSitePath(prefix + '_toc')
+  );
 
-    context.contentId = contentId;
+  context.contentId = contentId;
 
-    async.parallel({
-        content: function (callback) {
-            ContentService.get(context, contentId, {}, callback);
-        },
-        toc: function (callback) {
-            ContentService.get(context, tocId, {ignoreErrors: true}, function (err, toc) {
-                if (!toc) {
-                    return callback(null, null);
-                }
+  async.parallel({
+    content: function (callback) {
+      ContentService.get(context, contentId, {}, callback);
+    },
+    toc: function (callback) {
+      ContentService.get(context, tocId, {ignoreErrors: true}, function (err, toc) {
+        if (!toc) {
+          return callback(null, null);
+        }
 
-                var relativeUrls = /href=("|')(..\/)?([^\/].*?)("|')/g;
-                toc.envelope.body =
-                    toc.envelope.body.replace(
-                        relativeUrls,
-                        'href=$1' + prefix + '$3$4'
-                    );
+        var relativeUrls = /href=("|')(..\/)?([^\/].*?)("|')/g;
+        toc.envelope.body =
+          toc.envelope.body.replace(
+            relativeUrls,
+            'href=$1' + prefix + '$3$4'
+        );
 
-                return callback(null, toc.envelope.body);
-            });
-        },
-    }, function (err, output) {
+        return callback(null, toc.envelope.body);
+      });
+    },
+  }, function (err, output) {
+    if (err) {
+      return context.handleError(err);
+    }
+
+    if (output.toc) {
+      output.content.globals = {
+        toc: output.toc
+      };
+    }
+
+    var input = {
+      context: context,
+      content: output.content
+    };
+
+    ContentFilterService.filter(input, function (err, filterResult) {
+      if (err) {
+        return context.handleError(err);
+      }
+
+      var route = TemplateRoutingService.getRoute(context);
+      var filteredContent = filterResult.content;
+
+      TemplateService.render(context, route, filteredContent, function (err, renderedContent) {
         if (err) {
-            return context.handleError(err);
+          return context.handleError(err);
         }
 
-        if (output.toc) {
-            output.content.globals = {
-                toc: output.toc
-            };
-        }
-
-        var input = {
-            context: context,
-            content: output.content
-        };
-
-        ContentFilterService.filter(input, function (err, filterResult) {
-            if (err) {
-                return context.handleError(err);
-            }
-
-            var route = TemplateRoutingService.getRoute(context);
-            var filteredContent = filterResult.content;
-
-            TemplateService.render(context, route, filteredContent, function (err, renderedContent) {
-                if (err) {
-                    return context.handleError(err);
-                }
-
-                context.send(renderedContent);
-            });
-        });
+        context.send(renderedContent);
+      });
     });
+  });
 };

--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -1,28 +1,19 @@
 // Handler to assemble a specific piece of static content.
 
-var fs = require('fs'),
-  path = require('path'),
-  request = require('request'),
-  url = require('url'),
-  urljoin = require('url-join'),
-  async = require('async'),
-  handlebars = require('handlebars'),
-  _ = require('lodash'),
-  config = require('../config'),
-  logger = require('../server/logging').logger,
-  Context = require('../helpers/context'),
-  TemplateService = require('../services/template'),
-  TemplateRoutingService = require('../services/template-routing'),
-  ContentService = require('../services/content'),
-  ContentRoutingService = require('../services/content/routing'),
-  ContentFilterService = require('../services/content/filter'),
-  UrlService = require('../services/url');
+var async = require('async');
+var Context = require('../helpers/context');
+var TemplateService = require('../services/template');
+var TemplateRoutingService = require('../services/template-routing');
+var ContentService = require('../services/content');
+var ContentRoutingService = require('../services/content/routing');
+var ContentFilterService = require('../services/content/filter');
+var UrlService = require('../services/url');
 
 // Register content filters.
 
 ContentFilterService.add(function (input, next) {
-  var context = input.context,
-    content = input.content;
+  var context = input.context;
+  var content = input.content;
 
   // Match nunjucks-like "{{ to('') }}" directives that are used to defer rendering of presented URLs
   // until presenter-time.
@@ -42,16 +33,16 @@ ContentFilterService.add(function (input, next) {
 });
 
 ContentFilterService.add(function (input, next) {
-  var context = input.context,
-    content = input.content;
+  var context = input.context;
+  var content = input.content;
 
   // Locate the URLs for the content IDs of any next and previous links included in the
   // document.
-  if (content.next && content.next.contentID && ! content.next.url) {
+  if (content.next && content.next.contentID && !content.next.url) {
     content.next.url = ContentRoutingService.getPresentedUrl(context, content.next.contentID);
   }
 
-  if (content.previous && content.previous.contentID && ! content.previous.url) {
+  if (content.previous && content.previous.contentID && !content.previous.url) {
     content.previous.url = ContentRoutingService.getPresentedUrl(context, content.previous.contentID);
   }
 
@@ -75,7 +66,7 @@ module.exports = function (req, res) {
     },
     toc: function (callback) {
       ContentService.get(context, tocId, {ignoreErrors: true}, function (err, toc) {
-        if (!toc) {
+        if (err || !toc) {
           return callback(null, null);
         }
 
@@ -88,7 +79,7 @@ module.exports = function (req, res) {
 
         return callback(null, toc.envelope.body);
       });
-    },
+    }
   }, function (err, output) {
     if (err) {
       return context.handleError(err);

--- a/src/routers/crash.js
+++ b/src/routers/crash.js
@@ -4,5 +4,5 @@
 // forth. It should only be installed in non-production environments.
 
 module.exports = function (req, res) {
-    throw new Error("AHHHHHHHHHHHH MOTHERLAND");
+  throw new Error('AHHHHHHHHHHHH MOTHERLAND');
 };

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -6,10 +6,10 @@ var crash = require('./crash');
 var config = require('../config');
 
 exports.install = function (app) {
-    if (config.presenter_diagnostics()) {
-        app.get('/crash', crash);
-    }
+  if (config.presenter_diagnostics()) {
+    app.get('/crash', crash);
+  }
 
-    app.get('/version', version);
-    app.get('/*', content);
+  app.get('/version', version);
+  app.get('/*', content);
 };

--- a/src/routers/version.js
+++ b/src/routers/version.js
@@ -1,10 +1,9 @@
 // Handler to report the current application version.
 
-var
-  child_process = require("child_process"),
-  info = require("../../package.json");
+var child_process = require('child_process'),
+  info = require('../../package.json');
 
-var commit = child_process.execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim();
+var commit = child_process.execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
 
 module.exports = function (req, res) {
   res.json({

--- a/src/routers/version.js
+++ b/src/routers/version.js
@@ -1,9 +1,9 @@
 // Handler to report the current application version.
 
-var child_process = require('child_process'),
-  info = require('../../package.json');
+var childProcess = require('child_process');
+var info = require('../../package.json');
 
-var commit = child_process.execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+var commit = childProcess.execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
 
 module.exports = function (req, res) {
   res.json({

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -2,13 +2,13 @@
  * Create and configure an Express server to host the application.
  */
 
-var express = require('express'),
-  logging = require('./logging'),
-  proxies = require('./proxies'),
-  rewrites = require('./rewrites'),
-  routes = require('../routers'),
-  path = require('path'),
-  pathService = require('../services/path');
+var express = require('express');
+var logging = require('./logging');
+var proxies = require('./proxies');
+var rewrites = require('./rewrites');
+var routes = require('../routers');
+var path = require('path');
+var pathService = require('../services/path');
 
 exports.create = function () {
   var app = express();

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -2,35 +2,34 @@
  * Create and configure an Express server to host the application.
  */
 
-var
-    express = require('express'),
-    logging = require('./logging'),
-    proxies = require('./proxies'),
-    rewrites = require('./rewrites'),
-    routes = require('../routers'),
-    path = require('path'),
-    pathService = require('../services/path');
+var express = require('express'),
+  logging = require('./logging'),
+  proxies = require('./proxies'),
+  rewrites = require('./rewrites'),
+  routes = require('../routers'),
+  path = require('path'),
+  pathService = require('../services/path');
 
 exports.create = function () {
-    var app = express();
+  var app = express();
 
-    var staticPath = path.resolve(pathService.getControlRepoPath(), 'assets');
-    app.use('/assets', express.static(staticPath));
+  var staticPath = path.resolve(pathService.getControlRepoPath(), 'assets');
+  app.use('/assets', express.static(staticPath));
 
-    app.use(logging.requestLogger());
+  app.use(logging.requestLogger());
 
-    proxies(app);
-    rewrites(app);
-    routes.install(app);
+  proxies(app);
+  rewrites(app);
+  routes.install(app);
 
-    app.use(function (err, req, res, next) {
-        logging.logger.error({
-            stack: err.stack,
-            message: "Express.js error handler invoked"
-        });
-
-        res.status(500).send("Something went wrong.");
+  app.use(function (err, req, res, next) {
+    logging.logger.error({
+      stack: err.stack,
+      message: 'Express.js error handler invoked'
     });
 
-    return app;
+    res.status(500).send('Something went wrong.');
+  });
+
+  return app;
 };

--- a/src/server/logging.js
+++ b/src/server/logging.js
@@ -4,48 +4,48 @@ var config = require('../config');
 var activeTransports = [];
 
 if (process.env.NODE_ENV === 'production') {
-    activeTransports.push(new winston.transports.Console({
-        level: config.log_level().toLowerCase(),
-        prettyPrint: false,
-        colorize: config.log_colorize(),
-        timestamp: true,
-        json: true,
-        stringify: true,
-        handleExceptions: true
-    }));
+  activeTransports.push(new winston.transports.Console({
+    level: config.log_level().toLowerCase(),
+    prettyPrint: false,
+    colorize: config.log_colorize(),
+    timestamp: true,
+    json: true,
+    stringify: true,
+    handleExceptions: true
+  }));
 } else {
-    activeTransports.push(new winston.transports.Console({
-        level: config.log_level().toLowerCase(),
-        prettyPrint: true,
-        colorize: config.log_colorize(),
-        timestamp: true,
-    }));
+  activeTransports.push(new winston.transports.Console({
+    level: config.log_level().toLowerCase(),
+    prettyPrint: true,
+    colorize: config.log_colorize(),
+    timestamp: true,
+  }));
 }
 
 exports.logger = new winston.Logger({
-    levels: {
-        trace: 0,
-        debug: 1,
-        verbose: 2,
-        info: 3,
-        warn: 4,
-        error: 5
-    },
-    colors: {
-        trace: 'white',
-        debug: 'grey',
-        verbose: 'cyan',
-        info: 'green',
-        warn: 'yellow',
-        error: 'red'
-    },
-    transports: activeTransports
+  levels: {
+    trace: 0,
+    debug: 1,
+    verbose: 2,
+    info: 3,
+    warn: 4,
+    error: 5
+  },
+  colors: {
+    trace: 'white',
+    debug: 'grey',
+    verbose: 'cyan',
+    info: 'green',
+    warn: 'yellow',
+    error: 'red'
+  },
+  transports: activeTransports
 });
 
-exports.requestLogger = function() {
-    return function(req, res, next) {
-        exports.logger.verbose(req.method + ' ' + req.url);
-        req.log = exports.logger;
-        next();
-    };
+exports.requestLogger = function () {
+  return function (req, res, next) {
+    exports.logger.verbose(req.method + ' ' + req.url);
+    req.log = exports.logger;
+    next();
+  };
 };

--- a/src/server/logging.js
+++ b/src/server/logging.js
@@ -18,7 +18,7 @@ if (process.env.NODE_ENV === 'production') {
     level: config.log_level().toLowerCase(),
     prettyPrint: true,
     colorize: config.log_colorize(),
-    timestamp: true,
+    timestamp: true
   }));
 }
 

--- a/src/server/proxies.js
+++ b/src/server/proxies.js
@@ -4,29 +4,29 @@ var ContentRoutingService = require('../services/content/routing');
 var logger = require('./logging').logger;
 var request = require('request');
 
-function makeProxyRoute(site, path, target) {
-    return function (req, res, next) {
-        var host = config.presented_url_domain() || req.get('Host');
-        if (host !== site) {
-            return next();
-        }
+function makeProxyRoute (site, path, target) {
+  return function (req, res, next) {
+    var host = config.presented_url_domain() || req.get('Host');
+    if (host !== site) {
+      return next();
+    }
 
-        var suffix = url.parse(req.originalUrl).path.replace(path, '');
+    var suffix = url.parse(req.originalUrl).path.replace(path, '');
 
-        logger.debug("Proxy request: [" + target + suffix + "].");
-        var proxyRequest = request(target + suffix);
+    logger.debug('Proxy request: [' + target + suffix + '].');
+    var proxyRequest = request(target + suffix);
 
-        req.pipe(proxyRequest);
-        proxyRequest.pipe(res);
-    };
+    req.pipe(proxyRequest);
+    proxyRequest.pipe(res);
+  };
 }
 
 module.exports = function (app) {
-    var proxies = ContentRoutingService.getAllProxies();
+  var proxies = ContentRoutingService.getAllProxies();
 
-    proxies.forEach(function (each) {
-        for (var path in each.proxy) {
-            app.use(path + '*', makeProxyRoute(each.site, path, each.proxy[path]));
-        }
-    });
+  proxies.forEach(function (each) {
+    for (var path in each.proxy) {
+      app.use(path + '*', makeProxyRoute(each.site, path, each.proxy[path]));
+    }
+  });
 };

--- a/src/server/rewrites.js
+++ b/src/server/rewrites.js
@@ -22,7 +22,7 @@ module.exports = function (app) {
       logger.debug('Reading rewrites from %s', PathService.getConfigPath(rewritesFile));
     } catch (e) {
       logger.warn('No valid JSON file found at %s', PathService.getConfigPath(rewritesFile));
-      var rewritesFileData = [];
+      rewritesFileData = [];
     }
 
     app.use(function (req, res, next) {

--- a/src/server/rewrites.js
+++ b/src/server/rewrites.js
@@ -5,87 +5,87 @@ var logger = require('./logging').logger;
 var PathService = require('../services/path');
 
 module.exports = function (app) {
-    var userRewrites = function () {
-        /**
-         * @todo This same logic of reading JSON files is in a few places. It should be
-         *       abstracted into something like `ConfigService.readConfigFile(fileName)`
-         */
-        var rewritesFile = config.control_rewrites_file();
-        var rewritesFileData;
+  var userRewrites = function () {
+    /**
+     * @todo This same logic of reading JSON files is in a few places. It should be
+     *       abstracted into something like `ConfigService.readConfigFile(fileName)`
+     */
+    var rewritesFile = config.control_rewrites_file();
+    var rewritesFileData;
 
-        try {
-            rewritesFileData = JSON.parse(fs.readFileSync(
-                PathService.getConfigPath(rewritesFile),
-                'utf-8'
-            ));
+    try {
+      rewritesFileData = JSON.parse(fs.readFileSync(
+        PathService.getConfigPath(rewritesFile),
+        'utf-8'
+      ));
 
-            logger.debug('Reading rewrites from %s', PathService.getConfigPath(rewritesFile));
-        } catch (e) {
-            logger.warn('No valid JSON file found at %s', PathService.getConfigPath(rewritesFile));
-            var rewritesFileData = [];
-        }
+      logger.debug('Reading rewrites from %s', PathService.getConfigPath(rewritesFile));
+    } catch (e) {
+      logger.warn('No valid JSON file found at %s', PathService.getConfigPath(rewritesFile));
+      var rewritesFileData = [];
+    }
 
-        app.use(function (req, res, next) {
-            var stopProcessing = false;
-
-            var host = config.presented_url_domain() || req.get('Host');
-            var rewrites = rewritesFileData[host] || [];
-
-            rewrites.forEach(function (rule, index, scope) {
-                // Stop processing rules if a redirect has been sent
-                if (stopProcessing) {
-                    return;
-                }
-
-                var originalUrl = req.url;
-                var parsedUrl = url.parse(originalUrl, true);
-                var isRewrite = rule.rewrite || false;
-                var status = rule.status || 301;
-                var fromPattern = new RegExp(rule.from, 'g');
-
-                // If the pathname doesn't match the "from" pattern, get the
-                // heck outta here!
-                if (!parsedUrl.pathname.match(fromPattern)) {
-                    return;
-                }
-
-                // If the incoming URL's pathname matches the pattern, replace
-                // it with the rule's "to" pattern
-                parsedUrl.pathname = parsedUrl.pathname.replace(fromPattern, rule.to);
-                req.url = url.format(parsedUrl);
-
-                // Stop processing and redirect if this isn't a rewrite
-                if (!isRewrite) {
-                    logger.debug('Redirecting to %s', req.url);
-                    stopProcessing = true;
-                    return res.redirect(status, req.url);
-                }
-
-                logger.debug('Rewriting URL from %s to %s', originalUrl, req.url);
-            });
-
-            // If a redirect has been sent, don't process any other middlewares
-            if (!stopProcessing) {
-                next();
-            }
-        });
-    };
-
-    // Do system rewrites first
-
-    // Multiple slashes become a single slash.
     app.use(function (req, res, next) {
-        var emptySegment = /\/[\/]+/;
-        var parsedUrl = url.parse(req.url, true);
+      var stopProcessing = false;
 
-        if(emptySegment.test(parsedUrl.pathname)) {
-            parsedUrl.pathname = parsedUrl.pathname.replace(emptySegment, '/');
-            req.url = url.format(parsedUrl);
+      var host = config.presented_url_domain() || req.get('Host');
+      var rewrites = rewritesFileData[host] || [];
+
+      rewrites.forEach(function (rule, index, scope) {
+        // Stop processing rules if a redirect has been sent
+        if (stopProcessing) {
+          return;
         }
 
-        return next();
-    });
+        var originalUrl = req.url;
+        var parsedUrl = url.parse(originalUrl, true);
+        var isRewrite = rule.rewrite || false;
+        var status = rule.status || 301;
+        var fromPattern = new RegExp(rule.from, 'g');
 
-    // Then add the user's rewrites
-    userRewrites();
+        // If the pathname doesn't match the "from" pattern, get the
+        // heck outta here!
+        if (!parsedUrl.pathname.match(fromPattern)) {
+          return;
+        }
+
+        // If the incoming URL's pathname matches the pattern, replace
+        // it with the rule's "to" pattern
+        parsedUrl.pathname = parsedUrl.pathname.replace(fromPattern, rule.to);
+        req.url = url.format(parsedUrl);
+
+        // Stop processing and redirect if this isn't a rewrite
+        if (!isRewrite) {
+          logger.debug('Redirecting to %s', req.url);
+          stopProcessing = true;
+          return res.redirect(status, req.url);
+        }
+
+        logger.debug('Rewriting URL from %s to %s', originalUrl, req.url);
+      });
+
+      // If a redirect has been sent, don't process any other middlewares
+      if (!stopProcessing) {
+        next();
+      }
+    });
+  };
+
+  // Do system rewrites first
+
+  // Multiple slashes become a single slash.
+  app.use(function (req, res, next) {
+    var emptySegment = /\/[\/]+/;
+    var parsedUrl = url.parse(req.url, true);
+
+    if (emptySegment.test(parsedUrl.pathname)) {
+      parsedUrl.pathname = parsedUrl.pathname.replace(emptySegment, '/');
+      req.url = url.format(parsedUrl);
+    }
+
+    return next();
+  });
+
+  // Then add the user's rewrites
+  userRewrites();
 };

--- a/src/services/content/filter.js
+++ b/src/services/content/filter.js
@@ -2,18 +2,18 @@ var mware = require('mware')();
 var message = {};
 
 var ContentFilterService = {
-    add: function (fn) {
-        mware(fn);
-    },
+  add: function (fn) {
+    mware(fn);
+  },
 
-    filter: function (input, output) {
-        message = input;
+  filter: function (input, output) {
+    message = input;
 
-        mware.run(message, function (err) {
-            output(err, message);
-            message = {};
-        });
-    }
+    mware.run(message, function (err) {
+      output(err, message);
+      message = {};
+    });
+  }
 };
 
 module.exports = ContentFilterService;

--- a/src/services/content/index.js
+++ b/src/services/content/index.js
@@ -1,110 +1,109 @@
-var
-    request = require('request'),
-    config = require('../../config'),
-    logger = require('../../server/logging').logger,
-    urljoin = require('url-join');
+var request = require('request'),
+  config = require('../../config'),
+  logger = require('../../server/logging').logger,
+  urljoin = require('url-join');
 
-var INFRA_ERRORS = ['ENOTFOUND','ETIMEDOUT','ECONNREFUSED'];
+var INFRA_ERRORS = ['ENOTFOUND', 'ETIMEDOUT', 'ECONNREFUSED'];
 
 var ContentService = {
-    get: function (context, id, options, callback) {
-        if (!id) {
-            // without a contentID, this is like a 404
-            return callback({
-                statusCode: 404,
-                message: "Unable to locate content ID"
-            });
+  get: function (context, id, options, callback) {
+    if (!id) {
+      // without a contentID, this is like a 404
+      return callback({
+        statusCode: 404,
+        message: 'Unable to locate content ID'
+      });
+    }
+
+    var contentUrl = urljoin(
+      config.content_service_url(),
+      'content',
+      encodeURIComponent(id)
+    );
+
+    logger.debug('Content service request: [' + contentUrl + '].');
+    var reqStart = Date.now();
+
+    request(contentUrl, function (err, res, body) {
+      var reqDuration = Date.now() - reqStart;
+      context.contentReqDuration = reqDuration;
+
+      if (err) {
+        if (options.ignoreErrors === true) {
+          // This error should not be considered fatal
+          return callback(null, null);
         }
 
-        var contentUrl = urljoin(
-            config.content_service_url(),
-            'content',
-            encodeURIComponent(id)
-        );
+        if (err && err.code && INFRA_ERRORS.indexOf(err.code) !== -1) {
+          return callback({
+            statusCode: 503,
+            message: err.code,
+            contentReqDuration: reqDuration
+          });
+        }
 
-        logger.debug("Content service request: [" + contentUrl + "].");
-        var reqStart = Date.now();
+        return callback(err);
+      }
 
-        request(contentUrl, function (err, res, body) {
-            var reqDuration = Date.now() - reqStart;
-            context.contentReqDuration = reqDuration;
+      if (res.statusCode >= 400) {
+        var messageBody;
+        try {
+          messageBody = JSON.parse(body);
+        } catch (e) {
+          messageBody = body || 'Empty response';
+        }
 
-            if (err) {
-                if (options.ignoreErrors === true) {
-                    // This error should not be considered fatal
-                    return callback(null, null);
-                }
-
-                if (err && err.code && INFRA_ERRORS.indexOf(err.code) !== -1) {
-                    return callback({
-                        statusCode: 503,
-                        message: err.code,
-                        contentReqDuration: reqDuration
-                    });
-                }
-
-                return callback(err);
-            }
-
-            if (res.statusCode >= 400) {
-                var messageBody;
-                try {
-                    messageBody = JSON.parse(body);
-                } catch (e) {
-                    messageBody = body || "Empty response";
-                }
-
-                return callback({
-                    statusCode: res.statusCode,
-                    message: messageBody
-                });
-            }
-
-            logger.debug({
-                message: "Content service request: successful.",
-                contentReqDuration: reqDuration
-            });
-
-            callback(null, JSON.parse(body));
+        return callback({
+          statusCode: res.statusCode,
+          message: messageBody
         });
-    },
-    getAssets: function (context, callback) {
-        logger.debug("Content service request: requesting assets.");
-        var assetUrl = urljoin(config.content_service_url(), 'assets');
+      }
 
-        var reqStart = Date.now();
+      logger.debug({
+        message: 'Content service request: successful.',
+        contentReqDuration: reqDuration
+      });
 
-        request(assetUrl, function (err, res, body) {
-            var reqDuration = Date.now() - reqStart;
-            context.assetReqDuration = reqDuration;
+      callback(null, JSON.parse(body));
+    });
+  },
+  getAssets: function (context, callback) {
+    logger.debug('Content service request: requesting assets.');
+    var assetUrl = urljoin(config.content_service_url(), 'assets');
 
-            if (err) {
-                return callback(err);
-            }
+    var reqStart = Date.now();
 
-            if (res.statusCode >= 400) {
-                var messageBody;
-                try {
-                    messageBody = JSON.parse(body);
-                } catch (e) {
-                    messageBody = body || "Empty response";
-                }
+    request(assetUrl, function (err, res, body) {
+      var reqDuration = Date.now() - reqStart;
+      context.assetReqDuration = reqDuration;
 
-                return callback({
-                    statusCode: res.statusCode,
-                    message: messageBody,
-                    assetReqDuration: reqDuration
-                });
-            }
+      if (err) {
+        return callback(err);
+      }
 
-            logger.debug({
-                message: "Content service asset request: successful.",
-                assetReqDuration: reqDuration
-            });
+      if (res.statusCode >= 400) {
+        var messageBody;
+        try {
+          messageBody = JSON.parse(body);
+        } catch (e) {
+          messageBody = body || 'Empty response';
+        }
 
-            callback(null, JSON.parse(body));
+        return callback({
+          statusCode: res.statusCode,
+          message: messageBody,
+          assetReqDuration: reqDuration
         });
-    }
+      }
+
+      logger.debug({
+        message: 'Content service asset request: successful.',
+        assetReqDuration: reqDuration
+      });
+
+      callback(null, JSON.parse(body));
+    });
+  }
 };
 
 module.exports = ContentService;

--- a/src/services/content/index.js
+++ b/src/services/content/index.js
@@ -1,7 +1,7 @@
-var request = require('request'),
-  config = require('../../config'),
-  logger = require('../../server/logging').logger,
-  urljoin = require('url-join');
+var request = require('request');
+var config = require('../../config');
+var logger = require('../../server/logging').logger;
+var urljoin = require('url-join');
 
 var INFRA_ERRORS = ['ENOTFOUND', 'ETIMEDOUT', 'ECONNREFUSED'];
 

--- a/src/services/content/routing.js
+++ b/src/services/content/routing.js
@@ -9,104 +9,103 @@ var UrlService = require('../url');
 var CONTENT_FILE = config.control_content_file();
 
 var ContentRoutingService = {
-    _readContentConfig: function () {
-        try {
-            return JSON.parse(fs.readFileSync(
-                path.resolve(PathService.getConfigPath(), CONTENT_FILE),
-                'utf-8'
-            ));
-        } catch (e) {
-            logger.error('Unable to read ' + path.resolve(PathService.getConfigPath(), CONTENT_FILE));
-            return {};
-        }
-    },
-    _readContent: function (site) {
-        var contentConfig = this._readContentConfig();
-
-        if (!contentConfig.hasOwnProperty(site) || !contentConfig[site].hasOwnProperty('content')) {
-            logger.warn(CONTENT_FILE + ' has no content routes defined for this site.');
-            return {};
-        }
-
-        return contentConfig[site].content;
-    },
-    _readProxies: function (site) {
-        var contentConfig = this._readContentConfig();
-
-        if (!contentConfig.hasOwnProperty(site) || !contentConfig[site].hasOwnProperty('proxy')) {
-            return {};
-        }
-
-        return contentConfig[site].proxy;
-    },
-    getContentId: function (context, urlPath) {
-        urlPath = urlPath || context.request.path;
-        var content = this._readContent(context.host());
-
-        var contentStoreBase = null, afterPrefix = null;
-
-        for (var prefix in content) {
-            if(urlPath.indexOf(prefix) !== -1) {
-                contentStoreBase = content[prefix];
-                afterPrefix = urlPath.replace(prefix, '');
-            }
-        }
-
-        if (contentStoreBase === null) {
-            return null;
-        }
-
-        return url.resolve(contentStoreBase, afterPrefix).replace(/\/$/, '');
-    },
-    getContentPrefix: function (context) {
-        var urlPath = context.request.path;
-        var content = this._readContent(context.host());
-
-        var prefixMatch = null;
-
-        for(var prefix in content) {
-            if (urlPath.indexOf(prefix) !== -1) {
-                prefixMatch = prefix;
-            }
-        }
-
-        return prefixMatch;
-    },
-    getPresentedUrl: function (context, contentId) {
-        var
-            content = this._readContent(context.host()),
-            urlBase = null,
-            afterPrefix = null;
-
-        for (var prefix in content) {
-            if (contentId.indexOf(content[prefix].replace(/\/$/, '')) !== -1) {
-                urlBase = prefix;
-                afterPrefix = contentId.replace(content[prefix], '');
-            }
-        }
-
-        return UrlService.getSiteUrl(context, url.resolve(urlBase, afterPrefix));
-    },
-    getProxies: function (context) {
-        return this._readProxies(context.host());
-    },
-    getAllProxies: function () {
-        var proxies = [];
-
-        var contentConfig = this._readContentConfig();
-
-        for (var site in contentConfig) {
-            var siteConfig = contentConfig[site];
-            if (siteConfig.hasOwnProperty("proxy")) {
-                proxies.push({
-                    site: site,
-                    proxy: siteConfig.proxy
-                });
-            }
-        }
-
-        return proxies;
+  _readContentConfig: function () {
+    try {
+      return JSON.parse(fs.readFileSync(
+        path.resolve(PathService.getConfigPath(), CONTENT_FILE),
+        'utf-8'
+      ));
+    } catch (e) {
+      logger.error('Unable to read ' + path.resolve(PathService.getConfigPath(), CONTENT_FILE));
+      return {};
     }
+  },
+  _readContent: function (site) {
+    var contentConfig = this._readContentConfig();
+
+    if (!contentConfig.hasOwnProperty(site) || !contentConfig[site].hasOwnProperty('content')) {
+      logger.warn(CONTENT_FILE + ' has no content routes defined for this site.');
+      return {};
+    }
+
+    return contentConfig[site].content;
+  },
+  _readProxies: function (site) {
+    var contentConfig = this._readContentConfig();
+
+    if (!contentConfig.hasOwnProperty(site) || !contentConfig[site].hasOwnProperty('proxy')) {
+      return {};
+    }
+
+    return contentConfig[site].proxy;
+  },
+  getContentId: function (context, urlPath) {
+    urlPath = urlPath || context.request.path;
+    var content = this._readContent(context.host());
+
+    var contentStoreBase = null, afterPrefix = null;
+
+    for (var prefix in content) {
+      if (urlPath.indexOf(prefix) !== -1) {
+        contentStoreBase = content[prefix];
+        afterPrefix = urlPath.replace(prefix, '');
+      }
+    }
+
+    if (contentStoreBase === null) {
+      return null;
+    }
+
+    return url.resolve(contentStoreBase, afterPrefix).replace(/\/$/, '');
+  },
+  getContentPrefix: function (context) {
+    var urlPath = context.request.path;
+    var content = this._readContent(context.host());
+
+    var prefixMatch = null;
+
+    for (var prefix in content) {
+      if (urlPath.indexOf(prefix) !== -1) {
+        prefixMatch = prefix;
+      }
+    }
+
+    return prefixMatch;
+  },
+  getPresentedUrl: function (context, contentId) {
+    var content = this._readContent(context.host()),
+      urlBase = null,
+      afterPrefix = null;
+
+    for (var prefix in content) {
+      if (contentId.indexOf(content[prefix].replace(/\/$/, '')) !== -1) {
+        urlBase = prefix;
+        afterPrefix = contentId.replace(content[prefix], '');
+      }
+    }
+
+    return UrlService.getSiteUrl(context, url.resolve(urlBase, afterPrefix));
+  },
+  getProxies: function (context) {
+    return this._readProxies(context.host());
+  },
+  getAllProxies: function () {
+    var proxies = [];
+
+    var contentConfig = this._readContentConfig();
+
+    for (var site in contentConfig) {
+      var siteConfig = contentConfig[site];
+      if (siteConfig.hasOwnProperty('proxy')) {
+        proxies.push({
+          site: site,
+          proxy: siteConfig.proxy
+        });
+      }
+    }
+
+    return proxies;
+  }
 };
 
 module.exports = ContentRoutingService;

--- a/src/services/content/routing.js
+++ b/src/services/content/routing.js
@@ -43,7 +43,8 @@ var ContentRoutingService = {
     urlPath = urlPath || context.request.path;
     var content = this._readContent(context.host());
 
-    var contentStoreBase = null, afterPrefix = null;
+    var contentStoreBase = null;
+    var afterPrefix = null;
 
     for (var prefix in content) {
       if (urlPath.indexOf(prefix) !== -1) {
@@ -73,9 +74,9 @@ var ContentRoutingService = {
     return prefixMatch;
   },
   getPresentedUrl: function (context, contentId) {
-    var content = this._readContent(context.host()),
-      urlBase = null,
-      afterPrefix = null;
+    var content = this._readContent(context.host());
+    var urlBase = null;
+    var afterPrefix = null;
 
     for (var prefix in content) {
       if (contentId.indexOf(content[prefix].replace(/\/$/, '')) !== -1) {

--- a/src/services/nunjucks-fallback.js
+++ b/src/services/nunjucks-fallback.js
@@ -1,9 +1,9 @@
 module.exports = function () {
-    for(var key in arguments) {
-        if(arguments[key]) {
-            return arguments[key];
-        }
+  for (var key in arguments) {
+    if (arguments[key]) {
+      return arguments[key];
     }
+  }
 
-    return '';
+  return '';
 };

--- a/src/services/nunjucks.js
+++ b/src/services/nunjucks.js
@@ -5,95 +5,92 @@ var nunjucks = require('nunjucks');
 var nunjucksDate = require('nunjucks-date');
 var nunjucksFallback = require('./nunjucks-fallback');
 var services = {
-    path: require('./path')
+  path: require('./path')
 };
 
 var envs = {};
 
-function createEnvironment(context) {
-    var env = new nunjucks.Environment(
-        new nunjucks.FileSystemLoader([
-            services.path.getTemplatesPath(context),
-            services.path.getDefaultTemplatesPath()
-        ], { watch: true })
-    );
+function createEnvironment (context) {
+  var env = new nunjucks.Environment(
+    new nunjucks.FileSystemLoader([
+      services.path.getTemplatesPath(context),
+      services.path.getDefaultTemplatesPath()
+    ], { watch: true })
+  );
 
-    env.addFilter('date', nunjucksDate);
-    env.addFilter('fallback', nunjucksFallback);
+  env.addFilter('date', nunjucksDate);
+  env.addFilter('fallback', nunjucksFallback);
 
-    env.addFilter('json', function (data) {
-        var string = JSON.stringify(data, null, 4);
-        string = string.replace(/</g,'&lt;').replace(/>/g, '&gt;');
+  env.addFilter('json', function (data) {
+    var string = JSON.stringify(data, null, 4);
+    string = string.replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
-        return '<pre><code>' + string + '</code></pre>';
-    });
+    return '<pre><code>' + string + '</code></pre>';
+  });
 
-    addPlugins(env, context);
+  addPlugins(env, context);
 
-    return env;
+  return env;
 }
 
 var addPlugins = function (env, context) {
-    var pluginPath = services.path.getPluginsPath(context);
+  var pluginPath = services.path.getPluginsPath(context);
+  try {
+    fs.openSync(pluginPath, 'r');
+  } catch(e) {
+    logger.warn('Unable to find plugins directory at: ' + pluginPath);
+    return;
+  }
+
+  if (!fs.statSync(pluginPath).isDirectory()) {
+    return;
+  }
+
+  fs.readdirSync(pluginPath).forEach(function (pluginDir) {
+    var plugin;
+
     try {
-        fs.openSync(pluginPath, 'r');
-    }
-    catch(e) {
-        logger.warn('Unable to find plugins directory at: ' + pluginPath);
-        return;
-    }
-
-    if(!fs.statSync(pluginPath).isDirectory()) {
-        return;
+      plugin = require(path.join(pluginPath, pluginDir));
+    } catch(e) {
+      logger.error(e);
+      return;
     }
 
-    fs.readdirSync(pluginPath).forEach(function (pluginDir) {
-        var plugin;
+    if (plugin.templateFilters && plugin.templateFilters.length > 0) {
+      plugin.templateFilters.forEach(function (filter) {
+        var originalFilter = filter[1].bind(env);
 
-        try {
-            plugin = require(path.join(pluginPath, pluginDir));
-        }
-        catch(e) {
+        filter[1] = function (input) {
+          try {
+            return originalFilter.apply(env, arguments);
+          } catch(e) {
             logger.error(e);
-            return;
-        }
+            return input;
+          }
+        };
 
-        if(plugin.templateFilters && plugin.templateFilters.length > 0) {
-            plugin.templateFilters.forEach(function (filter) {
-                var originalFilter = filter[1].bind(env);
+        env.addFilter.apply(env, filter);
+      });
+    }
 
-                filter[1] = function (input) {
-                    try {
-                        return originalFilter.apply(env, arguments);
-                    }
-                    catch(e) {
-                        logger.error(e);
-                        return input;
-                    }
-                };
-
-                env.addFilter.apply(env, filter);
-            });
-        }
-
-    });
+  });
 };
 
 var NunjucksService = {
-    clearEnvironments: function () {
-        envs = {};
-    },
-    getEnvironment: function (context) {
-        var host = context.host();
+  clearEnvironments: function () {
+    envs = {};
+  },
+  getEnvironment: function (context) {
+    var host = context.host();
 
-        if (envs[host]) {
-            return envs[host];
-        }
-
-        var env = createEnvironment(context);
-        envs[host] = env;
-        return env;
+    if (envs[host]) {
+      return envs[host];
     }
+
+    var env = createEnvironment(context);
+    envs[host] = env;
+    return env;
+  }
 };
 
 module.exports = NunjucksService;

--- a/src/services/path.js
+++ b/src/services/path.js
@@ -4,24 +4,24 @@ var config = require('../config');
 var CONFIG_PATH = 'config';
 
 var PathService = {
-    getControlRepoPath: function () {
-        return path.resolve(config.control_repo_path());
-    },
-    getDefaultTemplatesPath: function () {
-        return path.resolve('./static');
-    },
-    getPluginsPath: function (context) {
-        var templatePath = 'plugins/' + context.host();
-        return path.resolve(this.getControlRepoPath(), templatePath);
-    },
-    getTemplatesPath: function (context) {
-        var templatePath = 'templates/' + context.host();
-        return path.resolve(this.getControlRepoPath(), templatePath);
-    },
-    getConfigPath: function (configPath) {
-        configPath = configPath || '';
-        return path.resolve(this.getControlRepoPath(), CONFIG_PATH, configPath);
-    }
+  getControlRepoPath: function () {
+    return path.resolve(config.control_repo_path());
+  },
+  getDefaultTemplatesPath: function () {
+    return path.resolve('./static');
+  },
+  getPluginsPath: function (context) {
+    var templatePath = 'plugins/' + context.host();
+    return path.resolve(this.getControlRepoPath(), templatePath);
+  },
+  getTemplatesPath: function (context) {
+    var templatePath = 'templates/' + context.host();
+    return path.resolve(this.getControlRepoPath(), templatePath);
+  },
+  getConfigPath: function (configPath) {
+    configPath = configPath || '';
+    return path.resolve(this.getControlRepoPath(), CONFIG_PATH, configPath);
+  }
 };
 
 module.exports = PathService;

--- a/src/services/template-data.js
+++ b/src/services/template-data.js
@@ -1,13 +1,11 @@
 var TemplateDataService = {
-    extend: function (data) {
-
-    },
-    getData: function () {
-        return {
-            foo: 'bar',
-            baz: 'bat'
-        };
-    }
+  extend: function (data) {},
+  getData: function () {
+    return {
+      foo: 'bar',
+      baz: 'bat'
+    };
+  }
 };
 
 module.exports = TemplateDataService;

--- a/src/services/template-routing.js
+++ b/src/services/template-routing.js
@@ -7,31 +7,31 @@ var PathService = require('../services/path');
 var ROUTES_FILE = config.control_routes_file();
 
 var TemplateRoutingService = {
-    _readRoutes: function (site) {
-        var routes =
-            JSON.parse(fs.readFileSync(
-                path.resolve(PathService.getConfigPath(), ROUTES_FILE),
-                'utf-8'
-            ))[site];
+  _readRoutes: function (site) {
+    var routes =
+    JSON.parse(fs.readFileSync(
+      path.resolve(PathService.getConfigPath(), ROUTES_FILE),
+      'utf-8'
+    ))[site];
 
-        return routes.routes;
-    },
-    getRoute: function (context) {
-        var urlPath = context.request.path;
-        var routes = this._readRoutes(context.host());
-        var bestMatch = null;
+    return routes.routes;
+  },
+  getRoute: function (context) {
+    var urlPath = context.request.path;
+    var routes = this._readRoutes(context.host());
+    var bestMatch = null;
 
-        for (var pattern in routes) {
-            var patternExpression = new RegExp(pattern);
-            if (patternExpression.test(urlPath)) {
-                bestMatch = routes[pattern];
-            }
-        }
-
-        bestMatch = bestMatch || 'index.html';
-        context.templatePath = bestMatch;
-        return bestMatch;
+    for (var pattern in routes) {
+      var patternExpression = new RegExp(pattern);
+      if (patternExpression.test(urlPath)) {
+        bestMatch = routes[pattern];
+      }
     }
+
+    bestMatch = bestMatch || 'index.html';
+    context.templatePath = bestMatch;
+    return bestMatch;
+  }
 };
 
 module.exports = TemplateRoutingService;

--- a/src/services/template-routing.js
+++ b/src/services/template-routing.js
@@ -1,6 +1,5 @@
 var fs = require('fs');
 var path = require('path');
-var url = require('url');
 var config = require('../config');
 var PathService = require('../services/path');
 

--- a/src/services/template.js
+++ b/src/services/template.js
@@ -4,72 +4,72 @@ var globby = require('globby');
 var path = require('path');
 var logger = require('../server/logging').logger;
 var services = {
-    content: require('./content'),
-    nunjucks: require('./nunjucks'),
-    path: require('./path'),
-    url: require('./url')
+  content: require('./content'),
+  nunjucks: require('./nunjucks'),
+  path: require('./path'),
+  url: require('./url')
 };
 
 var TemplateService = {
-    render: function (context, templatePath, data, callback) {
-        var templateFile = this._findTemplate(context, templatePath);
+  render: function (context, templatePath, data, callback) {
+    var templateFile = this._findTemplate(context, templatePath);
 
-        this._bootstrapContext(context, data, function (templateData) {
-            var startTimestamp = Date.now();
-            var env = services.nunjucks.getEnvironment(context);
-            env.render(templateFile, templateData, function (err, result) {
-                context.templateRenderDuration = Date.now() - startTimestamp;
+    this._bootstrapContext(context, data, function (templateData) {
+      var startTimestamp = Date.now();
+      var env = services.nunjucks.getEnvironment(context);
+      env.render(templateFile, templateData, function (err, result) {
+        context.templateRenderDuration = Date.now() - startTimestamp;
 
-                callback(err, result);
-            });
-        });
-    },
-    _bootstrapContext: function (context, content, callback) {
-        var ctx = {
-            deconst: {
-                env: process.env,
-                content: content || {},
-                url: services.url,
-                request: context.request,
-                response: context.response
-            }
-        };
+        callback(err, result);
+      });
+    });
+  },
+  _bootstrapContext: function (context, content, callback) {
+    var ctx = {
+      deconst: {
+        env: process.env,
+        content: content || {},
+        url: services.url,
+        request: context.request,
+        response: context.response
+      }
+    };
 
-        services.content.getAssets(context, function (err, data) {
-            ctx.deconst.assets = data;
-            callback(ctx);
-        });
-    },
-    _findTemplate: function (context, templatePath) {
-        templatePath = templatePath || 'index';
-        var templateDir = services.path.getTemplatesPath(context);
-        var defaultTemplateDir = services.path.getDefaultTemplatesPath();
-        var templateBase = path.resolve(templateDir, templatePath);
-        var defaultTemplateBase = path.resolve(defaultTemplateDir, templatePath);
+    services.content.getAssets(context, function (err, data) {
+      ctx.deconst.assets = data;
+      callback(ctx);
+    });
+  },
+  _findTemplate: function (context, templatePath) {
+    templatePath = templatePath || 'index';
+    var templateDir = services.path.getTemplatesPath(context);
+    var defaultTemplateDir = services.path.getDefaultTemplatesPath();
+    var templateBase = path.resolve(templateDir, templatePath);
+    var defaultTemplateBase = path.resolve(defaultTemplateDir, templatePath);
 
-        var matches = globby.sync([
-            templateBase,
-            templateBase + '.html',
-            templateBase + '.htm',
-            templateBase + '/index.html',
-            templateBase + '/index.htm',
-            defaultTemplateBase,
-            defaultTemplateBase + '.html',
-            defaultTemplateBase + '.htm',
-            defaultTemplateBase + '/index.html',
-            defaultTemplateBase + '/index.htm',
-        ]);
+    var matches = globby.sync([
+      templateBase,
+      templateBase + '.html',
+      templateBase + '.htm',
+      templateBase + '/index.html',
+      templateBase + '/index.htm',
+      defaultTemplateBase,
+      defaultTemplateBase + '.html',
+      defaultTemplateBase + '.htm',
+      defaultTemplateBase + '/index.html',
+      defaultTemplateBase + '/index.htm',
+    ]);
 
-        if (matches.length === 0 && templatePath !== "404.html") {
-            return this._findTemplate(context, "404.html");
-        }
-
-        if (matches.length === 0) {
-            throw new Error("Unable to find static 404 handler");
-        }
-
-        return matches[0].replace(templateDir + '/', '').replace(defaultTemplateDir + '/', '');
+    if (matches.length === 0 && templatePath !== '404.html') {
+      return this._findTemplate(context, '404.html');
     }
+
+    if (matches.length === 0) {
+      throw new Error('Unable to find static 404 handler');
+    }
+
+    return matches[0].replace(templateDir + '/', '').replace(defaultTemplateDir + '/', '');
+  }
 };
 
 module.exports = TemplateService;

--- a/src/services/url.js
+++ b/src/services/url.js
@@ -3,16 +3,16 @@ var url = require('url');
 var SITE_DIRECTORY = '/';
 
 var UrlService = {
-    getSiteUrl: function (context, path) {
-        path = path || '';
-        var siteUrl = context.protocol() + '://' + context.host();
+  getSiteUrl: function (context, path) {
+    path = path || '';
+    var siteUrl = context.protocol() + '://' + context.host();
 
-        return url.resolve(siteUrl + SITE_DIRECTORY, path);
-    },
-    getSitePath: function (path) {
-        path = path || '';
-        return url.resolve(SITE_DIRECTORY, path);
-    }
+    return url.resolve(siteUrl + SITE_DIRECTORY, path);
+  },
+  getSitePath: function (path) {
+    path = path || '';
+    return url.resolve(SITE_DIRECTORY, path);
+  }
 };
 
 module.exports = UrlService;

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -1,19 +1,17 @@
 // Unit tests for page assembly.
 
 var before = require('./helpers/before'),
-    config = require('../src/config');
+  config = require('../src/config');
 
 config.configure(before.settings);
 
-var
-  request = require('supertest'),
+var request = require('supertest'),
   nock = require('nock'),
   server = require('../src/server');
 
 nock.enableNetConnect('127.0.0.1');
 
 describe('page assembly', function () {
-
   beforeEach(function () {
     config.configure(before.settings);
   });
@@ -27,23 +25,23 @@ describe('page assembly', function () {
       });
 
     request(server.create())
-        .get('/')
-        .expect(200)
-        .expect(/the page content/, done);
+      .get('/')
+      .expect(200)
+      .expect(/the page content/, done);
   });
 
   it('ignores empty URL segments', function (done) {
     var content = nock('http://content')
-        .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Ffoo')
-        .reply(200, {
-          assets: [],
-          envelope: { body: 'the page content' }
-        });
+      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Ffoo')
+      .reply(200, {
+        assets: [],
+        envelope: { body: 'the page content' }
+      });
 
-      request(server.create())
-          .get('/////foo')
-          .expect(200)
-          .expect(/the page content/, done);
+    request(server.create())
+      .get('/////foo')
+      .expect(200)
+      .expect(/the page content/, done);
   });
 
   it('returns the user-defined 404 template', function (done) {
@@ -56,7 +54,6 @@ describe('page assembly', function () {
       .expect(404)
       .expect(/user-defined 404 template/, done);
   });
-
 
   it('passes other failing status codes through', function (done) {
     var content = nock('http://content')

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -1,13 +1,14 @@
+/* globals it describe beforeEach */
 // Unit tests for page assembly.
 
-var before = require('./helpers/before'),
-  config = require('../src/config');
+var before = require('./helpers/before');
+var config = require('../src/config');
 
 config.configure(before.settings);
 
-var request = require('supertest'),
-  nock = require('nock'),
-  server = require('../src/server');
+var request = require('supertest');
+var nock = require('nock');
+var server = require('../src/server');
 
 nock.enableNetConnect('127.0.0.1');
 
@@ -17,7 +18,7 @@ describe('page assembly', function () {
   });
 
   it('assembles a page', function (done) {
-    var content = nock('http://content')
+    nock('http://content')
       .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
       .reply(200, {
         assets: [],
@@ -31,7 +32,7 @@ describe('page assembly', function () {
   });
 
   it('ignores empty URL segments', function (done) {
-    var content = nock('http://content')
+    nock('http://content')
       .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Ffoo')
       .reply(200, {
         assets: [],
@@ -45,7 +46,7 @@ describe('page assembly', function () {
   });
 
   it('returns the user-defined 404 template', function (done) {
-    var content = nock('http://content')
+    nock('http://content')
       .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
       .reply(404);
 
@@ -56,7 +57,7 @@ describe('page assembly', function () {
   });
 
   it('passes other failing status codes through', function (done) {
-    var content = nock('http://content')
+    nock('http://content')
       .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
       .reply(409);
 

--- a/test/config.js
+++ b/test/config.js
@@ -1,7 +1,8 @@
+/* globals it describe */
 // Unit tests for the configuration system.
 
-var expect = require('chai').expect,
-  config = require('../src/config');
+var expect = require('chai').expect;
+var config = require('../src/config');
 
 describe('config', function () {
   it('reads configuration values from the environment', function () {
@@ -32,7 +33,7 @@ describe('config', function () {
   it('defaults the log level', function () {
     config.configure({
       CONTROL_REPO_PATH: './test/test-control',
-      CONTENT_SERVICE_URL: 'https://content',
+      CONTENT_SERVICE_URL: 'https://content'
     });
 
     expect(config.log_level()).to.equal('info');
@@ -41,7 +42,7 @@ describe('config', function () {
   it('normalizes service URLs', function () {
     config.configure({
       CONTROL_REPO_PATH: './test/test-control',
-      CONTENT_SERVICE_URL: 'https://content/',
+      CONTENT_SERVICE_URL: 'https://content/'
     });
 
     expect(config.content_service_url()).to.equal('https://content');

--- a/test/config.js
+++ b/test/config.js
@@ -1,50 +1,49 @@
 // Unit tests for the configuration system.
 
-var
-  expect = require("chai").expect,
-  config = require("../src/config");
+var expect = require('chai').expect,
+  config = require('../src/config');
 
-describe("config", function () {
-  it("reads configuration values from the environment", function () {
+describe('config', function () {
+  it('reads configuration values from the environment', function () {
     config.configure({
       CONTROL_REPO_PATH: './test/test-control',
-      CONTENT_SERVICE_URL: "https://content",
-      PRESENTED_URL_PROTO: "http",
-      PRESENTED_URL_DOMAIN: "deconst.horse",
-      PUBLIC_URL_PROTO: "https",
-      PUBLIC_URL_DOMAIN: "localhost",
-      PRESENTER_LOG_LEVEL: "debug"
+      CONTENT_SERVICE_URL: 'https://content',
+      PRESENTED_URL_PROTO: 'http',
+      PRESENTED_URL_DOMAIN: 'deconst.horse',
+      PUBLIC_URL_PROTO: 'https',
+      PUBLIC_URL_DOMAIN: 'localhost',
+      PRESENTER_LOG_LEVEL: 'debug'
     });
 
-    expect(config.content_service_url()).to.equal("https://content");
-    expect(config.presented_url_proto()).to.equal("http");
-    expect(config.presented_url_domain()).to.equal("deconst.horse");
-    expect(config.public_url_proto()).to.equal("https");
-    expect(config.public_url_domain()).to.equal("localhost");
-    expect(config.log_level()).to.equal("debug");
+    expect(config.content_service_url()).to.equal('https://content');
+    expect(config.presented_url_proto()).to.equal('http');
+    expect(config.presented_url_domain()).to.equal('deconst.horse');
+    expect(config.public_url_proto()).to.equal('https');
+    expect(config.public_url_domain()).to.equal('localhost');
+    expect(config.log_level()).to.equal('debug');
   });
 
-  it("requires service URLs", function () {
-      expect(function () {
-        config.configure({});
-      }).to.throw(Error, /Inadequate configuration/);
+  it('requires service URLs', function () {
+    expect(function () {
+      config.configure({});
+    }).to.throw(Error, /Inadequate configuration/);
   });
 
-  it("defaults the log level", function () {
+  it('defaults the log level', function () {
     config.configure({
       CONTROL_REPO_PATH: './test/test-control',
-      CONTENT_SERVICE_URL: "https://content",
+      CONTENT_SERVICE_URL: 'https://content',
     });
 
-    expect(config.log_level()).to.equal("info");
+    expect(config.log_level()).to.equal('info');
   });
 
-  it("normalizes service URLs", function () {
+  it('normalizes service URLs', function () {
     config.configure({
       CONTROL_REPO_PATH: './test/test-control',
-      CONTENT_SERVICE_URL: "https://content/",
+      CONTENT_SERVICE_URL: 'https://content/',
     });
 
-    expect(config.content_service_url()).to.equal("https://content");
-});
+    expect(config.content_service_url()).to.equal('https://content');
+  });
 });

--- a/test/control-repo.js
+++ b/test/control-repo.js
@@ -1,16 +1,15 @@
-var before = require('./helpers/before'),
-  config = require('../src/config');
+/* globals it describe beforeEach afterEach */
+
+var before = require('./helpers/before');
+var config = require('../src/config');
 
 config.configure(before.settings);
 
-var fs = require('fs'),
-  path = require('path'),
-  request = require('supertest'),
-  nock = require('nock'),
-  mockfs = require('mock-fs'),
-  server = require('../src/server'),
-  PathService = require('../src/services/path'),
-  NunjucksService = require('../src/services/nunjucks');
+var request = require('supertest');
+var nock = require('nock');
+var mockfs = require('mock-fs');
+var server = require('../src/server');
+var NunjucksService = require('../src/services/nunjucks');
 
 nock.enableNetConnect('127.0.0.1');
 
@@ -28,10 +27,10 @@ describe('[control-repo] the app', function () {
     mockfs({
       'test/test-control/templates/deconst.horse': {
         '404.html': 'site 404 page'
-      },
+      }
     });
 
-    var content = nock('http://content')
+    nock('http://content')
       .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
       .reply(200, {
         assets: [],
@@ -65,7 +64,7 @@ describe('[control-repo] the app', function () {
       CONTROL_REWRITES_FILE: 'foo.json'
     });
 
-    var content = nock('http://content')
+    nock('http://content')
       .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
       .reply(200, {
         assets: [],
@@ -82,7 +81,7 @@ describe('[control-repo] the app', function () {
       PRESENTED_URL_DOMAIN: 'fake-site.dev'
     });
 
-    var content = nock('http://content')
+    nock('http://content')
       .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
       .reply(200, {
         assets: [],

--- a/test/control-repo.js
+++ b/test/control-repo.js
@@ -1,96 +1,96 @@
 var before = require('./helpers/before'),
-    config = require('../src/config');
+  config = require('../src/config');
 
 config.configure(before.settings);
 
 var fs = require('fs'),
-    path = require('path'),
-    request = require('supertest'),
-    nock = require('nock'),
-    mockfs = require('mock-fs'),
-    server = require("../src/server"),
-    PathService = require("../src/services/path"),
-    NunjucksService = require("../src/services/nunjucks");
+  path = require('path'),
+  request = require('supertest'),
+  nock = require('nock'),
+  mockfs = require('mock-fs'),
+  server = require('../src/server'),
+  PathService = require('../src/services/path'),
+  NunjucksService = require('../src/services/nunjucks');
 
-nock.enableNetConnect("127.0.0.1");
+nock.enableNetConnect('127.0.0.1');
 
 describe('[control-repo] the app', function () {
-    beforeEach(function () {
-      config.configure(before.settings);
-      NunjucksService.clearEnvironments();
+  beforeEach(function () {
+    config.configure(before.settings);
+    NunjucksService.clearEnvironments();
+  });
+
+  afterEach(function () {
+    mockfs.restore();
+  });
+
+  it('returns a 404 with a nonexistent control repo', function (done) {
+    mockfs({
+      'test/test-control/templates/deconst.horse': {
+        '404.html': 'site 404 page'
+      },
     });
 
-    afterEach(function () {
-        mockfs.restore();
+    var content = nock('http://content')
+      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
+      .reply(200, {
+        assets: [],
+        envelope: {body: 'the page content'}
+      });
+
+    request(server.create())
+      .get('/')
+      .expect(404)
+      .expect('site 404 page', done);
+  });
+
+  it('returns a 404 with a malformed content config file', function (done) {
+    mockfs({
+      'test/test-control/config': {
+        'content.json': '{notJson: "false"}'
+      },
+      'test/test-control/templates/deconst.horse': {
+        '404.html': 'site 404 page'
+      }
     });
 
-    it('returns a 404 with a nonexistent control repo', function (done) {
-        mockfs({
-            'test/test-control/templates/deconst.horse': {
-                '404.html': 'site 404 page'
-            },
-        });
+    request(server.create())
+      .get('/')
+      .expect(404)
+      .expect('site 404 page', done);
+  });
 
-        var content = nock('http://content')
-            .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
-            .reply(200, {
-              assets: [],
-              envelope: {body: 'the page content'}
-            });
-
-        request(server.create())
-          .get('/')
-          .expect(404)
-          .expect('site 404 page', done);
+  it('does not require a rewrites.json file', function (done) {
+    config.set({
+      CONTROL_REWRITES_FILE: 'foo.json'
     });
 
-    it('returns a 404 with a malformed content config file', function (done) {
-        mockfs({
-            'test/test-control/config': {
-                'content.json': '{notJson: "false"}'
-            },
-            'test/test-control/templates/deconst.horse': {
-                '404.html': 'site 404 page'
-            }
-        });
+    var content = nock('http://content')
+      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
+      .reply(200, {
+        assets: [],
+        envelope: {body: 'the page content'}
+      });
 
-        request(server.create())
-          .get('/')
-          .expect(404)
-          .expect("site 404 page", done);
+    request(server.create())
+      .get('/')
+      .expect(200, done);
+  });
+
+  it('404 on umnatched domains/hostnames', function (done) {
+    config.set({
+      PRESENTED_URL_DOMAIN: 'fake-site.dev'
     });
 
-    it('does not require a rewrites.json file', function (done) {
-        config.set({
-            CONTROL_REWRITES_FILE: 'foo.json'
-        });
+    var content = nock('http://content')
+      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
+      .reply(200, {
+        assets: [],
+        envelope: {body: 'the page content'}
+      });
 
-        var content = nock('http://content')
-            .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
-            .reply(200, {
-              assets: [],
-              envelope: {body: 'the page content'}
-            });
-
-        request(server.create())
-            .get('/')
-            .expect(200, done);
-    });
-
-    it('404 on umnatched domains/hostnames', function (done) {
-        config.set({
-            PRESENTED_URL_DOMAIN: 'fake-site.dev'
-        });
-
-        var content = nock('http://content')
-            .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
-            .reply(200, {
-              assets: [],
-              envelope: {body: 'the page content'}
-            });
-
-        request(server.create())
-            .get('/')
-            .expect(404, done);
-    });
+    request(server.create())
+      .get('/')
+      .expect(404, done);
+  });
 });

--- a/test/helpers/before.js
+++ b/test/helpers/before.js
@@ -1,9 +1,9 @@
 // Common setup functions for unit tests.
 
 exports.settings = {
-    CONTROL_REPO_PATH: './test/test-control',
-    CONTENT_SERVICE_URL: 'http://content',
-    PRESENTED_URL_PROTO: 'https',
-    PRESENTED_URL_DOMAIN: 'deconst.horse',
-    PRESENTER_LOG_LEVEL: process.env.PRESENTER_LOG_LEVEL
+  CONTROL_REPO_PATH: './test/test-control',
+  CONTENT_SERVICE_URL: 'http://content',
+  PRESENTED_URL_PROTO: 'https',
+  PRESENTED_URL_DOMAIN: 'deconst.horse',
+  PRESENTER_LOG_LEVEL: process.env.PRESENTER_LOG_LEVEL
 };

--- a/test/proxied.js
+++ b/test/proxied.js
@@ -1,14 +1,15 @@
+/* globals it describe beforeEach */
 // Unit tests for proxied services.
 
-var before = require('./helpers/before'),
-  config = require('../src/config'),
-  NunjucksService = require('../src/services/nunjucks');
+var before = require('./helpers/before');
+var config = require('../src/config');
+var NunjucksService = require('../src/services/nunjucks');
 
 config.configure(before.settings);
 
-var request = require('supertest'),
-  nock = require('nock'),
-  server = require('../src/server');
+var request = require('supertest');
+var nock = require('nock');
+var server = require('../src/server');
 
 nock.enableNetConnect('127.0.0.1');
 
@@ -19,7 +20,7 @@ describe('proxied services', function () {
   });
 
   it('handles proxied content', function (done) {
-    var content = nock('http://deconst.dog')
+    nock('http://deconst.dog')
       .get('/')
       .reply(200, 'static content');
 
@@ -30,7 +31,7 @@ describe('proxied services', function () {
   });
 
   it('handles proxied content in subdirectories', function (done) {
-    var content = nock('http://deconst.dog')
+    nock('http://deconst.dog')
       .get('/foo')
       .reply(200, 'foo content');
 
@@ -41,7 +42,7 @@ describe('proxied services', function () {
   });
 
   it('preserves headers from the upstream service', function (done) {
-    var content = nock('http://deconst.dog')
+    nock('http://deconst.dog')
       .get('/foo')
       .reply(200, 'foo content', {
         'Content-Type': 'text/plain',
@@ -57,7 +58,7 @@ describe('proxied services', function () {
   });
 
   it('preserves response status from the upstream service', function (done) {
-    var content = nock('http://deconst.dog')
+    nock('http://deconst.dog')
       .get('/foo')
       .reply(409, 'NOPE');
 

--- a/test/proxied.js
+++ b/test/proxied.js
@@ -1,72 +1,69 @@
 // Unit tests for proxied services.
 
-var
-    before = require("./helpers/before"),
-    config = require('../src/config'),
-    NunjucksService = require("../src/services/nunjucks");
+var before = require('./helpers/before'),
+  config = require('../src/config'),
+  NunjucksService = require('../src/services/nunjucks');
 
 config.configure(before.settings);
 
-var
-  request = require("supertest"),
-  nock = require("nock"),
-  server = require("../src/server");
+var request = require('supertest'),
+  nock = require('nock'),
+  server = require('../src/server');
 
-nock.enableNetConnect("127.0.0.1");
+nock.enableNetConnect('127.0.0.1');
 
-describe("proxied services", function () {
-
+describe('proxied services', function () {
   beforeEach(function () {
     config.configure(before.settings);
     NunjucksService.clearEnvironments();
   });
 
-  it("handles proxied content", function (done) {
-    var content = nock("http://deconst.dog")
-      .get("/")
-      .reply(200, "static content");
+  it('handles proxied content', function (done) {
+    var content = nock('http://deconst.dog')
+      .get('/')
+      .reply(200, 'static content');
 
     request(server.create())
-      .get("/proxy")
+      .get('/proxy')
       .expect(200)
-      .expect("static content", done);
+      .expect('static content', done);
   });
 
-  it("handles proxied content in subdirectories", function (done) {
-    var content = nock("http://deconst.dog")
-      .get("/foo")
-      .reply(200, "foo content");
+  it('handles proxied content in subdirectories', function (done) {
+    var content = nock('http://deconst.dog')
+      .get('/foo')
+      .reply(200, 'foo content');
 
     request(server.create())
-      .get("/proxy/foo")
+      .get('/proxy/foo')
       .expect(200)
-      .expect("foo content", done);
+      .expect('foo content', done);
   });
 
-  it("preserves headers from the upstream service", function (done) {
-    var content = nock("http://deconst.dog")
-      .get("/foo")
-      .reply(200, "foo content", {
-        "Content-Type": "text/plain",
-        "X-Some-Header": "neeeeigh"
+  it('preserves headers from the upstream service', function (done) {
+    var content = nock('http://deconst.dog')
+      .get('/foo')
+      .reply(200, 'foo content', {
+        'Content-Type': 'text/plain',
+        'X-Some-Header': 'neeeeigh'
       });
 
     request(server.create())
-      .get("/proxy/foo")
+      .get('/proxy/foo')
       .expect(200)
-      .expect("Content-Type", "text/plain")
-      .expect("X-Some-Header", "neeeeigh")
-      .expect("foo content", done);
+      .expect('Content-Type', 'text/plain')
+      .expect('X-Some-Header', 'neeeeigh')
+      .expect('foo content', done);
   });
 
-  it("preserves response status from the upstream service", function (done) {
-    var content = nock("http://deconst.dog")
-      .get("/foo")
-      .reply(409, "NOPE");
+  it('preserves response status from the upstream service', function (done) {
+    var content = nock('http://deconst.dog')
+      .get('/foo')
+      .reply(409, 'NOPE');
 
     request(server.create())
-      .get("/proxy/foo")
+      .get('/proxy/foo')
       .expect(409)
-      .expect("NOPE", done);
+      .expect('NOPE', done);
   });
 });

--- a/test/version.js
+++ b/test/version.js
@@ -1,27 +1,26 @@
 // Unit tests for the version endpoint.
 
-var config = require("../src/config");
+var config = require('../src/config');
 
 settings = {
   CONTROL_REPO_PATH: './test/test-control',
-  CONTENT_SERVICE_URL: "http://content",
-  PRESENTED_URL_DOMAIN: "deconst.horse"
+  CONTENT_SERVICE_URL: 'http://content',
+  PRESENTED_URL_DOMAIN: 'deconst.horse'
 };
 
 config.configure(settings);
 
-var
-  request = require("supertest"),
-  expect = require("chai").expect,
-  server = require("../src/server"),
-  info = require("../package.json");
+var request = require('supertest'),
+  expect = require('chai').expect,
+  server = require('../src/server'),
+  info = require('../package.json');
 
-describe("/version", function () {
-  it("reports the running application version", function (done) {
+describe('/version', function () {
+  it('reports the running application version', function (done) {
     request(server.create())
-      .get("/version")
+      .get('/version')
       .expect(200)
-      .expect("Content-Type", /json/)
+      .expect('Content-Type', /json/)
       .expect(function (res) {
         expect(res.body.service).to.equal(info.name);
         expect(res.body.version).to.equal(info.version);

--- a/test/version.js
+++ b/test/version.js
@@ -1,8 +1,9 @@
+/* globals it describe */
 // Unit tests for the version endpoint.
 
 var config = require('../src/config');
 
-settings = {
+var settings = {
   CONTROL_REPO_PATH: './test/test-control',
   CONTENT_SERVICE_URL: 'http://content',
   PRESENTED_URL_DOMAIN: 'deconst.horse'
@@ -10,10 +11,10 @@ settings = {
 
 config.configure(settings);
 
-var request = require('supertest'),
-  expect = require('chai').expect,
-  server = require('../src/server'),
-  info = require('../package.json');
+var request = require('supertest');
+var expect = require('chai').expect;
+var server = require('../src/server');
+var info = require('../package.json');
 
 describe('/version', function () {
   it('reports the running application version', function (done) {


### PR DESCRIPTION
I don't have terribly strong opinions about JavaScript style conventions, but having been spoiled by `go fmt`, I _do_ much prefer having something that can be enforced as automatically as possible, and I want something that's consistent across all of our node repositories. To that end I'd like to adopt [semistandard](https://github.com/Flet/semistandard).

I've been using @rgbkrk's [gag fork](https://github.com/rgbkrk/obama) in the content service and it's been fine so far. I like that it's basically drop-in-and-run with no configuration to fiddle with.

@ktbartholomew, any objections or strong opinions here?
