### PR TITLE
save NPM caches in the system tmpdir so we know it's writable

### DIFF
--- a/src/services/nunjucks.js
+++ b/src/services/nunjucks.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var os = require('os');
 var async = require('async');
 var npm = require('npm');
 var logger = require('../server/logging').logger;
@@ -63,7 +64,9 @@ var addPlugins = function (env, context, callback) {
       pluginDependencies = [];
     }
 
-    npm.load({}, function (err) {
+    npm.load({
+      cache: path.join(os.tmpdir(), '.npmcache')
+    }, function (err) {
       if (err) {
         return callback(err, env);
       }


### PR DESCRIPTION
The default cache location of `~/.npm` isn't writable by the node user in our docker containers. This will instead place the cache at something like `/tmp/.npmcache`, but uses Node's `os.tmpdir()` just in case the OS has somewhere else they'd like to put it.
