### PR TITLE
start as root, then run app as node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /usr/src/app
 RUN useradd node
 RUN npm install -g nodemon
 RUN mkdir -p /home/node /usr/src/app && chown -R node:node /home/node
-RUN mkdir -p /var/control-repo && chown -R node:node /var/control-repo
 
 COPY package.json /usr/src/app/
 RUN npm install
@@ -13,5 +12,4 @@ COPY . /usr/src/app
 
 EXPOSE 8080
 
-USER node
-CMD [ "npm", "start" ]
+CMD chown -R node:node /var/control-repo && su -c "npm start" node


### PR DESCRIPTION
This initially runs the container as root, so we have the ability to set up the environment after the container has been started. After that, it runs the node application as node.
