### PR TITLE
Fix the production container user.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ RUN apk add --update nodejs git && rm -rf /var/cache/apk/*
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
-RUN adduser -D node
+RUN adduser -D -s /bin/sh presenter
 RUN npm install -g nodemon
-RUN mkdir -p /home/node /usr/src/app && chown -R node:node /home/node
+RUN mkdir -p /home/presenter /usr/src/app && chown -R presenter:presenter /home/presenter
 
 COPY package.json /usr/src/app/
 RUN npm install
@@ -14,4 +14,4 @@ COPY . /usr/src/app
 
 EXPOSE 8080
 
-CMD chown -R node:node ${CONTROL_REPO_PATH} && su -c "npm start" node
+CMD ["/usr/src/app/script/prod"]

--- a/script/prod
+++ b/script/prod
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -euo pipefail
+
+[ -d /usr/src/app ] || {
+  echo "This script is intended to be executed inside the docker container."
+  exit 1
+}
+
+[ -n "${CONTROL_REPO_PATH}" ] || {
+  echo "Please set \${CONTROL_REPO_PATH} to the path within the container at which the control repository is mounted."
+  exit 1
+}
+
+chown -R presenter:presenter "${CONTROL_REPO_PATH}"
+exec /usr/bin/su presenter -c 'npm start'


### PR DESCRIPTION
In alpine, if you run `adduser -D`, it creates an `/etc/password` entry for the user with a default shell of "n". No idea why, but specifying the shell explicitly fixes this.

While I was investigating, I refactored the container's CMD into a standalone script and changed the username to "presenter."

Fixes deconst/client#45.
