### PR TITLE
Host redirects

### DIFF
--- a/src/server/rewrites.js
+++ b/src/server/rewrites.js
@@ -54,7 +54,7 @@ module.exports = function (app) {
         parsedUrl.pathname = parsedUrl.pathname.replace(fromPattern, rule.to);
 
         // Set hostname and port independently.
-        delete parsedUrl['host'];
+        delete parsedUrl.host;
 
         // Replace the host, protocol, and port only if configured to do so.
         if (rule.toProtocol !== undefined) {

--- a/src/server/rewrites.js
+++ b/src/server/rewrites.js
@@ -52,6 +52,21 @@ module.exports = function (app) {
         // If the incoming URL's pathname matches the pattern, replace
         // it with the rule's "to" pattern
         parsedUrl.pathname = parsedUrl.pathname.replace(fromPattern, rule.to);
+
+        // Set hostname and port independently.
+        delete parsedUrl['host'];
+
+        // Replace the host, protocol, and port only if configured to do so.
+        if (rule.toProtocol !== undefined) {
+          parsedUrl.protocol = rule.toProtocol;
+        }
+        if (rule.toHostname !== undefined) {
+          parsedUrl.hostname = rule.toHostname;
+        }
+        if (rule.toPort !== undefined) {
+          parsedUrl.port = rule.toPort;
+        }
+
         req.url = url.format(parsedUrl);
 
         // Stop processing and redirect if this isn't a rewrite

--- a/test/control-repo.js
+++ b/test/control-repo.js
@@ -99,5 +99,4 @@ describe('[control-repo] the app', function () {
       .expect('Location', 'https://stable.horse/some-path/')
       .expect(301, done);
   });
-
 });

--- a/test/control-repo.js
+++ b/test/control-repo.js
@@ -92,4 +92,12 @@ describe('[control-repo] the app', function () {
       .get('/')
       .expect(404, done);
   });
+
+  it('returns a redirect to a different hostname', function (done) {
+    request(server.create())
+      .get('/different-host/some-path/')
+      .expect('Location', 'https://stable.horse/some-path/')
+      .expect(301, done);
+  });
+
 });

--- a/test/test-control/config/rewrites.json
+++ b/test/test-control/config/rewrites.json
@@ -1,3 +1,12 @@
 {
-    "deconst.horse": []
+  "deconst.horse": [
+    {
+      "from": "^\\/different-host/(.*)?$",
+      "to": "/$1",
+      "to_protocol": "https",
+      "to_host": "stable.horse",
+      "rewrite": false,
+      "status": 301
+    }
+  ]
 }

--- a/test/test-control/config/rewrites.json
+++ b/test/test-control/config/rewrites.json
@@ -3,8 +3,8 @@
     {
       "from": "^\\/different-host/(.*)?$",
       "to": "/$1",
-      "to_protocol": "https",
-      "to_host": "stable.horse",
+      "toProtocol": "https",
+      "toHostname": "stable.horse",
       "rewrite": false,
       "status": 301
     }


### PR DESCRIPTION
Allow `rewrites.json` rules to also specify different hostnames, protocols, and ports for their redirect destinations.
