### PR TITLE
Disable Nunjucks autoescaping

### DIFF
--- a/src/services/nunjucks/index.js
+++ b/src/services/nunjucks/index.js
@@ -55,7 +55,9 @@ module.exports = NunjucksService;
 
 var createEnvironment = function (domain, loaders) {
   loaders.push(staticLoader);
-  var env = new nunjucks.Environment(loaders);
+  var env = new nunjucks.Environment(loaders, {
+    autoescape: false
+  });
 
   env.addFilter('date', nunjucksDate);
   env.addFilter('fallback', fallback);


### PR DESCRIPTION
The new nunjucks version autoescapes by default, which is probably wise. None of our content is dynamic and user-provided, though, so we can safely leave it off.
