### PR TITLE
Perform searches and display results from a template filter

### DIFF
--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -63,6 +63,20 @@ module.exports = function (req, res) {
 
   async.parallel({
     content: function (callback) {
+      if (contentId === ContentRoutingService.UNMAPPED) {
+        return callback({
+          statusCode: 404,
+          message: 'Unable to locate content ID'
+        });
+      }
+
+      if (contentId === ContentRoutingService.EMPTY_ENVELOPE) {
+        return callback(null, {
+          title: '',
+          body: ''
+        });
+      }
+
       ContentService.get(context, contentId, {}, callback);
     },
     toc: function (callback) {

--- a/src/services/content/index.js
+++ b/src/services/content/index.js
@@ -104,6 +104,59 @@ var ContentService = {
       callback(null, JSON.parse(body));
     });
   },
+  getSearch: function (q, pageNumber, perPage, callback) {
+    var searchUrl = urljoin(config.content_service_url(), 'search');
+    var searchQuery = {
+      q: q,
+      pageNumber: pageNumber,
+      perPage: perPage
+    };
+    var reqStart = Date.now();
+
+    logger.debug('Content service request: performing search.', {
+      url: searchUrl,
+      query: searchQuery
+    });
+
+    request({ url: searchUrl, qs: searchQuery }, function (err, res, body) {
+      var reqDuration = Date.now() - reqStart;
+      if (err) return callback(err);
+
+      if (res.statusCode === 404) {
+        // Compatibility with older content services
+        return callback(null, { total: 0, results: [] });
+      }
+
+      if (res.statusCode >= 400) {
+        var messageBody;
+        try {
+          messageBody = JSON.parse(body);
+        } catch (e) {
+          messageBody = body || 'Empty response';
+        }
+
+        return callback({
+          statusCode: res.statusCode,
+          message: messageBody,
+          searchReqDuration: reqDuration
+        });
+      }
+
+      var doc = {};
+      try {
+        doc = JSON.parse(body);
+      } catch (e) {
+        return callback(e);
+      }
+
+      logger.debug('Content service request: search successful.', {
+        resultCount: doc.results.length,
+        searchReqDuration: reqDuration
+      });
+
+      callback(null, doc);
+    });
+  },
   getControlSHA: function (context, callback) {
     var shaUrl = urljoin(config.content_service_url(), 'control');
     var reqStart = Date.now();

--- a/src/services/content/routing.js
+++ b/src/services/content/routing.js
@@ -61,19 +61,25 @@ var ContentRoutingService = {
 
     return prefixMatch;
   },
-  getPresentedUrl: function (context, contentId) {
+  getPresentedUrl: function (context, contentId, crossDomain) {
     var domainContentMaps = [];
 
-    if (context) {
-      domainContentMaps.push(getDomainContentMap(context.host()));
+    if (crossDomain) {
+      domainContentMaps = Object.keys(contentMap).map(function (k) {
+        return getDomainContentMap(k);
+      });
     } else {
-      domainContentMaps = Object.keys(contentMap);
+      domainContentMaps.push(getDomainContentMap(context.host()));
     }
 
     var urlBase = null;
     var afterPrefix = null;
 
     domainContentMaps.forEach(function (domainContentMap) {
+      if (urlBase !== null && afterPrefix !== null) {
+        return;
+      }
+
       for (var prefix in domainContentMap) {
         if (contentId.indexOf(domainContentMap[prefix].replace(/\/$/, '')) !== -1) {
           urlBase = prefix;

--- a/src/services/content/routing.js
+++ b/src/services/content/routing.js
@@ -62,18 +62,32 @@ var ContentRoutingService = {
     return prefixMatch;
   },
   getPresentedUrl: function (context, contentId) {
-    var domainContentMap = getDomainContentMap(context.host());
+    var domainContentMaps = [];
+
+    if (context) {
+      domainContentMaps.push(getDomainContentMap(context.host()));
+    } else {
+      domainContentMaps = Object.keys(contentMap);
+    }
+
     var urlBase = null;
     var afterPrefix = null;
 
-    for (var prefix in domainContentMap) {
-      if (contentId.indexOf(domainContentMap[prefix].replace(/\/$/, '')) !== -1) {
-        urlBase = prefix;
-        afterPrefix = contentId.replace(domainContentMap[prefix], '');
+    domainContentMaps.forEach(function (domainContentMap) {
+      for (var prefix in domainContentMap) {
+        if (contentId.indexOf(domainContentMap[prefix].replace(/\/$/, '')) !== -1) {
+          urlBase = prefix;
+          afterPrefix = contentId.replace(domainContentMap[prefix], '');
+          break;
+        }
       }
-    }
+    });
 
-    return UrlService.getSiteUrl(context, url.resolve(urlBase, afterPrefix));
+    if (urlBase !== null && afterPrefix !== null) {
+      return UrlService.getSiteUrl(context, url.resolve(urlBase, afterPrefix));
+    } else {
+      return null;
+    }
   },
   getProxies: function (context) {
     return getDomainProxyMap(context.host());

--- a/src/services/nunjucks/index.js
+++ b/src/services/nunjucks/index.js
@@ -5,6 +5,7 @@ var logger = require('../../server/logging').logger;
 var fallback = require('./fallback');
 var createAtomicLoader = require('./atomic-loader');
 var PathService = require('../path');
+var ContentService = require('../content');
 
 var envs = {};
 var staticEnv = null;
@@ -67,6 +68,9 @@ var createEnvironment = function (domain, loaders) {
 
     return '<pre><code>' + string + '</code></pre>';
   });
+  env.addFilter('search', function (query, pageNumber, perPage, callback) {
+    ContentService.getSearch(query, pageNumber, perPage, callback);
+  }, true);
 
   return env;
 };

--- a/src/services/nunjucks/index.js
+++ b/src/services/nunjucks/index.js
@@ -80,6 +80,9 @@ var createEnvironment = function (domain, loaders) {
         return each.url !== null;
       });
 
+      // Compute the page count as well.
+      r.pages = Math.ceil(r.total / (perPage || 10));
+
       callback(null, r);
     });
   }, true);

--- a/src/services/url.js
+++ b/src/services/url.js
@@ -2,16 +2,23 @@ var url = require('url');
 
 var SITE_DIRECTORY = '/';
 
+var withTrailingSlash = function (u) {
+  if (u[u.length - 1] === '/') {
+    return u;
+  }
+  return u + '/';
+};
+
 var UrlService = {
   getSiteUrl: function (context, path) {
     path = path || '';
     var siteUrl = context.protocol() + '://' + context.host();
 
-    return url.resolve(siteUrl + SITE_DIRECTORY, path);
+    return withTrailingSlash(url.resolve(siteUrl + SITE_DIRECTORY, path));
   },
   getSitePath: function (path) {
     path = path || '';
-    return url.resolve(SITE_DIRECTORY, path);
+    return withTrailingSlash(url.resolve(SITE_DIRECTORY, path));
   }
 };
 

--- a/src/services/url.js
+++ b/src/services/url.js
@@ -10,9 +10,11 @@ var withTrailingSlash = function (u) {
 };
 
 var UrlService = {
-  getSiteUrl: function (context, path) {
+  getSiteUrl: function (context, path, domain) {
     path = path || '';
-    var siteUrl = context.protocol() + '://' + context.host();
+    domain = domain || context.host();
+
+    var siteUrl = context.protocol() + '://' + domain;
 
     return withTrailingSlash(url.resolve(siteUrl + SITE_DIRECTORY, path));
   },

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -95,9 +95,9 @@ describe('page assembly', function () {
     nock('http://content')
       .get('/control')
       .reply(200, { sha: null })
-      .get('/search?q=term&pageNumber=2&perPage=20')
+      .get('/search?q=term&pageNumber=3&perPage=2')
       .reply(200, {
-        total: 2,
+        total: 11,
         results: [
           {
             contentID: 'https://github.com/deconst/fake/one',
@@ -113,8 +113,10 @@ describe('page assembly', function () {
       });
 
     request(server.create())
-      .get('/search/?notq=term&notpagenum=2&notperpage=20')
+      .get('/search/?notq=term&notpagenum=3&notperpage=2')
       .expect(200)
+      .expect(/Total results: 11\b/)
+      .expect(/Number of pages: 6\b/)
       .expect(/0: url https:\/\/deconst\.horse\/one\//)
       .expect(/0: title first/)
       .expect(/0: excerpt this <em>is<\/em> result one/)

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -95,7 +95,7 @@ describe('page assembly', function () {
     nock('http://content')
       .get('/control')
       .reply(200, { sha: null })
-      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
+      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fsearch')
       .reply(200, {
         assets: [],
         envelope: { body: 'this is ignored' }

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -95,11 +95,6 @@ describe('page assembly', function () {
     nock('http://content')
       .get('/control')
       .reply(200, { sha: null })
-      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fsearch')
-      .reply(200, {
-        assets: [],
-        envelope: { body: 'this is ignored' }
-      })
       .get('/search?q=term&pageNumber=2&perPage=20')
       .reply(200, {
         total: 2,
@@ -132,11 +127,6 @@ describe('page assembly', function () {
     nock('http://content')
       .get('/control')
       .reply(200, { sha: null })
-      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fsearch')
-      .reply(200, {
-        assets: [],
-        envelope: { body: 'this is ignored' }
-      })
       .get('/search?q=term')
       .reply(200, {
         total: 1,

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -127,4 +127,33 @@ describe('page assembly', function () {
       .expect(/1: title second/)
       .expect(/1: excerpt this <em>is<\/em> result two/, done);
   });
+
+  it('performs cross-domain searches', function (done) {
+    nock('http://content')
+      .get('/control')
+      .reply(200, { sha: null })
+      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fsearch')
+      .reply(200, {
+        assets: [],
+        envelope: { body: 'this is ignored' }
+      })
+      .get('/search?q=term')
+      .reply(200, {
+        total: 1,
+        results: [
+          {
+            contentID: 'https://github.com/deconst-dog/fake/one',
+            title: 'first',
+            excerpt: 'this <em>is</em> a cross-domain result'
+          }
+        ]
+      });
+
+    request(server.create())
+      .get('/search/?notq=term')
+      .expect(200)
+      .expect(/0: url https:\/\/deconst\.dog\/one\//)
+      .expect(/0: title first/)
+      .expect(/0: excerpt this <em>is<\/em> a cross-domain result/, done);
+  });
 });

--- a/test/test-control/config/content.json
+++ b/test/test-control/config/content.json
@@ -1,7 +1,8 @@
 {
     "deconst.horse": {
         "content": {
-            "/": "https://github.com/deconst/fake/"
+            "/": "https://github.com/deconst/fake/",
+            "/search": null
         },
         "proxy": {
             "/proxy": "http://deconst.dog"

--- a/test/test-control/config/routes.json
+++ b/test/test-control/config/routes.json
@@ -1,7 +1,8 @@
 {
     "deconst.horse": {
         "routes": {
-            "^/": "default"
+            "^/": "default",
+            "^/search/$": "search.html"
         }
     }
 }

--- a/test/test-control/templates/deconst.horse/search.html
+++ b/test/test-control/templates/deconst.horse/search.html
@@ -1,0 +1,9 @@
+{% set query = deconst.request.query %}
+
+{% for result in query.notq|search(query.notpagenum, query.notperpage) %}
+{{ loop.index0 }}: url {{ result.url }}
+{{ loop.index0 }}: title {{ result.title }}
+{{ loop.index0 }}: excerpt {{ result.excerpt }}
+{% else %}
+no results
+{% endfor %}

--- a/test/test-control/templates/deconst.horse/search.html
+++ b/test/test-control/templates/deconst.horse/search.html
@@ -1,6 +1,9 @@
-{% set query = deconst.request.query %}
+{% set query = deconst.request.query -%}
+{% set r = query.notq|search(query.notpagenum, query.notperpage) -%}
 
-{% for result in query.notq|search(query.notpagenum, query.notperpage) %}
+Total results: {{ r.total }}
+
+{% for result in r.results %}
 {{ loop.index0 }}: url {{ result.url }}
 {{ loop.index0 }}: title {{ result.title }}
 {{ loop.index0 }}: excerpt {{ result.excerpt }}

--- a/test/test-control/templates/deconst.horse/search.html
+++ b/test/test-control/templates/deconst.horse/search.html
@@ -2,6 +2,7 @@
 {% set r = query.notq|search(query.notpagenum, query.notperpage) -%}
 
 Total results: {{ r.total }}
+Number of pages: {{ r.pages }}
 
 {% for result in r.results %}
 {{ loop.index0 }}: url {{ result.url }}


### PR DESCRIPTION
Create a Nunjucks filter that can be used to perform searches against the content service.
- [x] Support cross-domain search results.
- [x] Map paths to `null` to route to an empty document.
- [x] Compute the number of pages in the result object.
- [x] Prepare documentation PR.

The next piece of deconst/deconst-docs#187.
