### PR TITLE
Search filter blows up with default parameters

### DIFF
--- a/src/services/content/index.js
+++ b/src/services/content/index.js
@@ -106,11 +106,9 @@ var ContentService = {
   },
   getSearch: function (q, pageNumber, perPage, callback) {
     var searchUrl = urljoin(config.content_service_url(), 'search');
-    var searchQuery = {
-      q: q,
-      pageNumber: pageNumber,
-      perPage: perPage
-    };
+    var searchQuery = {q: q};
+    if (pageNumber !== null && pageNumber !== undefined) searchQuery.pageNumber = pageNumber;
+    if (perPage !== null && perPage !== undefined) searchQuery.perPage = perPage;
     var reqStart = Date.now();
 
     logger.debug('Content service request: performing search.', {

--- a/src/services/nunjucks/index.js
+++ b/src/services/nunjucks/index.js
@@ -72,6 +72,16 @@ var createEnvironment = function (domain, loaders) {
   env.addFilter('search', function (query, pageNumber, perPage, callback) {
     var context = this.ctx.deconst.context;
 
+    // perPage and pageNumber are optional.
+    if (!(callback instanceof Function)) {
+      callback = perPage;
+      perPage = null;
+    }
+    if (!(callback instanceof Function)) {
+      callback = pageNumber;
+      pageNumber = null;
+    }
+
     ContentService.getSearch(query, pageNumber, perPage, function (err, r) {
       if (err) return callback(err);
 

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -125,7 +125,7 @@ describe('page assembly', function () {
       .expect(/1: excerpt this <em>is<\/em> result two/, done);
   });
 
-  it.only('performs a search with default parameters', function (done) {
+  it('performs a search with default parameters', function (done) {
     nock('http://content')
       .get('/control')
       .reply(200, { sha: null })

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -125,6 +125,31 @@ describe('page assembly', function () {
       .expect(/1: excerpt this <em>is<\/em> result two/, done);
   });
 
+  it.only('performs a search with default parameters', function (done) {
+    nock('http://content')
+      .get('/control')
+      .reply(200, { sha: null })
+      .get('/search?q=term')
+      .reply(200, {
+        total: 1,
+        results: [
+          {
+            contentID: 'https://github.com/deconst/fake/one',
+            title: 'first',
+            excerpt: 'this <em>is</em> result one'
+          }
+        ]
+      });
+
+    request(server.create())
+      .get('/searchparams/?q=term')
+      .expect(200)
+      .expect(/Total results: 1\b/)
+      .expect(/Number of pages: 1\b/)
+      .expect(/0: url https:\/\/deconst\.horse\/one\//)
+      .expect(/0: title first/, done);
+  });
+
   it('performs cross-domain searches', function (done) {
     nock('http://content')
       .get('/control')

--- a/test/test-control/config/content.json
+++ b/test/test-control/config/content.json
@@ -2,7 +2,8 @@
     "deconst.horse": {
         "content": {
             "/": "https://github.com/deconst/fake/",
-            "/search": null
+            "/search": null,
+            "/searchparams": null
         },
         "proxy": {
             "/proxy": "http://deconst.dog"

--- a/test/test-control/config/routes.json
+++ b/test/test-control/config/routes.json
@@ -2,7 +2,8 @@
     "deconst.horse": {
         "routes": {
             "^/": "default",
-            "^/search/$": "search.html"
+            "^/search/?$": "search.html",
+            "^/searchparams/?$": "searchparams.html"
         }
     }
 }

--- a/test/test-control/templates/deconst.horse/searchparams.html
+++ b/test/test-control/templates/deconst.horse/searchparams.html
@@ -1,0 +1,13 @@
+{% set query = deconst.request.query -%}
+{% set r = query.q|search -%}
+
+Total results: {{ r.total }}
+Number of pages: {{ r.pages }}
+
+{% for result in r.results %}
+{{ loop.index0 }}: url {{ result.url }}
+{{ loop.index0 }}: title {{ result.title }}
+{{ loop.index0 }}: excerpt {{ result.excerpt }}
+{% else %}
+no results
+{% endfor %}


### PR DESCRIPTION
It turns out that default filter parameters and async filters don't mix well without some actual work.
