### PR TITLE
Don't request unmapped TOC content

### DIFF
--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -63,20 +63,6 @@ module.exports = function (req, res) {
 
   async.parallel({
     content: function (callback) {
-      if (contentId === ContentRoutingService.UNMAPPED) {
-        return callback({
-          statusCode: 404,
-          message: 'Unable to locate content ID'
-        });
-      }
-
-      if (contentId === ContentRoutingService.EMPTY_ENVELOPE) {
-        return callback(null, {
-          title: '',
-          body: ''
-        });
-      }
-
       ContentService.get(context, contentId, {}, callback);
     },
     toc: function (callback) {

--- a/src/services/content/index.js
+++ b/src/services/content/index.js
@@ -9,8 +9,6 @@ var INFRA_ERRORS = ['ENOTFOUND', 'ETIMEDOUT', 'ECONNREFUSED'];
 
 var ContentService = {
   get: function (context, id, options, callback) {
-    console.trace('fetching id = ' + id);
-
     if (id === ContentRoutingService.UNMAPPED) {
       // with an unampped id, this is like a 404
       return callback({

--- a/src/services/content/index.js
+++ b/src/services/content/index.js
@@ -3,15 +3,27 @@ var config = require('../../config');
 var logger = require('../../server/logging').logger;
 var urljoin = require('url-join');
 
+var ContentRoutingService = require('./routing');
+
 var INFRA_ERRORS = ['ENOTFOUND', 'ETIMEDOUT', 'ECONNREFUSED'];
 
 var ContentService = {
   get: function (context, id, options, callback) {
-    if (!id) {
-      // without a contentID, this is like a 404
+    console.trace('fetching id = ' + id);
+
+    if (id === ContentRoutingService.UNMAPPED) {
+      // with an unampped id, this is like a 404
       return callback({
         statusCode: 404,
         message: 'Unable to locate content ID'
+      });
+    }
+
+    if (id === ContentRoutingService.EMPTY_ENVELOPE) {
+      // hardwired to return an empty envelope
+      return callback(null, {
+        title: '',
+        body: ''
       });
     }
 

--- a/src/services/content/index.js
+++ b/src/services/content/index.js
@@ -10,7 +10,7 @@ var INFRA_ERRORS = ['ENOTFOUND', 'ETIMEDOUT', 'ECONNREFUSED'];
 var ContentService = {
   get: function (context, id, options, callback) {
     if (id === ContentRoutingService.UNMAPPED) {
-      // with an unampped id, this is like a 404
+      // with an unmapped id, this is a 404
       return callback({
         statusCode: 404,
         message: 'Unable to locate content ID'


### PR DESCRIPTION
If the `_toc` ID isn't even mapped, don't bother querying the content service for it.
