### PR TITLE
Fetch assets explicitly and asynchronously

### DIFF
--- a/src/helpers/context.js
+++ b/src/helpers/context.js
@@ -74,7 +74,7 @@ Context.prototype.handleError = function (err) {
     code = 404;
   }
 
-  TemplateService.render(this, code.toString(), {}, {}, function (err, responseBody) {
+  TemplateService.render(this, {templatePath: code.toString()}, function (err, responseBody) {
     if (err) {
       logger.error("I couldn't render an error template. I'm freaking out!", err);
       responseBody = "Er, I was going to render an error template, but I couldn't.";

--- a/src/helpers/context.js
+++ b/src/helpers/context.js
@@ -74,7 +74,7 @@ Context.prototype.handleError = function (err) {
     code = 404;
   }
 
-  TemplateService.render(this, code.toString(), {}, function (err, responseBody) {
+  TemplateService.render(this, code.toString(), {}, {}, function (err, responseBody) {
     if (err) {
       logger.error("I couldn't render an error template. I'm freaking out!", err);
       responseBody = "Er, I was going to render an error template, but I couldn't.";

--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -125,14 +125,15 @@ module.exports = function (req, res) {
     };
 
     ContentFilterService.filter(input, function (err, filterResult) {
-      if (err) {
-        return context.handleError(err);
-      }
+      if (err) return context.handleError(err);
 
-      var templatePath = TemplateRoutingService.getRoute(context);
-      var filteredContent = filterResult.content;
+      var options = {
+        templatePath: TemplateRoutingService.getRoute(context),
+        content: filterResult.content,
+        assets: output.assets
+      };
 
-      TemplateService.render(context, templatePath, filteredContent, output.assets, function (err, renderedContent) {
+      TemplateService.render(context, options, function (err, renderedContent) {
         if (err) {
           return context.handleError(err);
         }

--- a/src/services/template/index.js
+++ b/src/services/template/index.js
@@ -1,11 +1,8 @@
 var globby = require('globby');
 var path = require('path');
-var services = {
-  content: require('../content'),
-  nunjucks: require('../nunjucks'),
-  path: require('../path'),
-  url: require('../url')
-};
+var NunjucksService = require('../nunjucks');
+var PathService = require('../path');
+var UrlService = require('../url');
 
 var TemplateService = {
   render: function (context, options, callback) {
@@ -13,7 +10,7 @@ var TemplateService = {
     var templateLocals = buildTemplateLocals(context, options.content, options.assets);
     var startTs = Date.now();
 
-    services.nunjucks.getEnvironment(context, function (err, env) {
+    NunjucksService.getEnvironment(context, function (err, env) {
       if (err) return callback(err);
 
       env.render(templateFile, templateLocals, function (err, result) {
@@ -38,7 +35,7 @@ var buildTemplateLocals = function (context, content, assets) {
       env: process.env,
       content: content || {},
       assets: assets || {},
-      url: services.url,
+      url: UrlService,
       context: context,
       request: context.request,
       response: context.response
@@ -49,7 +46,7 @@ var buildTemplateLocals = function (context, content, assets) {
 var findTemplate = function (context, templatePath) {
   templatePath = templatePath || 'index';
 
-  var defaultTemplateDir = services.path.getDefaultTemplatesPath();
+  var defaultTemplateDir = PathService.getDefaultTemplatesPath();
   var defaultTemplateBase = path.resolve(defaultTemplateDir, templatePath);
 
   var possibilities = [
@@ -62,7 +59,7 @@ var findTemplate = function (context, templatePath) {
 
   var templateDir = null;
   if (context.host()) {
-    templateDir = services.path.getTemplatesPath(context.host());
+    templateDir = PathService.getTemplatesPath(context.host());
     var templateBase = path.resolve(templateDir, templatePath);
 
     possibilities = possibilities.concat([

--- a/src/services/template/index.js
+++ b/src/services/template/index.js
@@ -8,9 +8,9 @@ var services = {
 };
 
 var TemplateService = {
-  render: function (context, templatePath, content, assets, callback) {
-    var templateFile = findTemplate(context, templatePath);
-    var templateLocals = buildTemplateLocals(context, content, assets);
+  render: function (context, options, callback) {
+    var templateFile = findTemplate(context, options.templatePath);
+    var templateLocals = buildTemplateLocals(context, options.content, options.assets);
     var startTs = Date.now();
 
     services.nunjucks.getEnvironment(context, function (err, env) {

--- a/src/services/template/index.js
+++ b/src/services/template/index.js
@@ -1,6 +1,5 @@
 var globby = require('globby');
 var path = require('path');
-var logger = require('../../server/logging').logger;
 var services = {
   content: require('../content'),
   nunjucks: require('../nunjucks'),
@@ -9,99 +8,80 @@ var services = {
 };
 
 var TemplateService = {
-  render: function (context, templatePath, data, callback) {
-    var templateFile = this._findTemplate(context, templatePath);
+  render: function (context, templatePath, content, assets, callback) {
+    var templateFile = findTemplate(context, templatePath);
+    var templateLocals = buildTemplateLocals(context, content, assets);
+    var startTs = Date.now();
 
-    this._bootstrapContext(context, data, function (err, templateData) {
-      if (err) {
-        return callback(err);
-      }
+    services.nunjucks.getEnvironment(context, function (err, env) {
+      if (err) return callback(err);
 
-      var startTimestamp = Date.now();
+      env.render(templateFile, templateLocals, function (err, result) {
+        context.templateRenderDuration = Date.now() - startTs;
 
-      services.nunjucks.getEnvironment(context, function (err, env) {
-        if (err) {
-          logger.error(err);
-        }
-
-        env.render(templateFile, templateData, function (err, result) {
-          context.templateRenderDuration = Date.now() - startTimestamp;
-
-          callback(err, result);
-        });
+        callback(err, result);
       });
     });
-  },
-  _bootstrapContext: function (context, content, callback) {
-    var ctx = {
-      deconst: {
-        env: process.env,
-        content: content || {},
-        url: services.url,
-        context: context,
-        request: context.request,
-        response: context.response
-      }
-    };
-
-    services.content.getAssets(context, function (err, data) {
-      if (err) {
-        logger.warn('Error retrieving assets from content store', {
-          errMessage: err.message,
-          stack: err.stack
-        });
-
-        ctx.deconst.assets = {};
-      } else {
-        ctx.deconst.assets = data;
-      }
-      callback(null, ctx);
-    });
-  },
-  _findTemplate: function (context, templatePath) {
-    templatePath = templatePath || 'index';
-
-    var defaultTemplateDir = services.path.getDefaultTemplatesPath();
-    var defaultTemplateBase = path.resolve(defaultTemplateDir, templatePath);
-
-    var possibilities = [
-      defaultTemplateBase,
-      defaultTemplateBase + '.html',
-      defaultTemplateBase + '.htm',
-      defaultTemplateBase + '/index.html',
-      defaultTemplateBase + '/index.htm'
-    ];
-
-    var templateDir = null;
-    if (context.host()) {
-      templateDir = services.path.getTemplatesPath(context.host());
-      var templateBase = path.resolve(templateDir, templatePath);
-
-      possibilities = possibilities.concat([
-        templateBase,
-        templateBase + '.html',
-        templateBase + '.htm',
-        templateBase + '/index.html',
-        templateBase + '/index.htm'
-      ]);
-    }
-
-    var matches = globby.sync(possibilities);
-
-    if (matches.length === 0 && templatePath !== '404.html') {
-      return this._findTemplate(context, '404.html');
-    }
-
-    if (matches.length === 0) {
-      throw new Error('Unable to find static 404 handler');
-    }
-
-    var m = matches[0].replace(defaultTemplateDir + '/', '');
-    if (templateDir) {
-      m = m.replace(templateDir + '/', '');
-    }
-    return m;
   }
 };
 
 module.exports = TemplateService;
+
+var buildTemplateLocals = function (context, content, assets) {
+  return {
+    deconst: {
+      env: process.env,
+      content: content || {},
+      assets: assets || {},
+      url: services.url,
+      context: context,
+      request: context.request,
+      response: context.response
+    }
+  };
+};
+
+var findTemplate = function (context, templatePath) {
+  templatePath = templatePath || 'index';
+
+  var defaultTemplateDir = services.path.getDefaultTemplatesPath();
+  var defaultTemplateBase = path.resolve(defaultTemplateDir, templatePath);
+
+  var possibilities = [
+    defaultTemplateBase,
+    defaultTemplateBase + '.html',
+    defaultTemplateBase + '.htm',
+    defaultTemplateBase + '/index.html',
+    defaultTemplateBase + '/index.htm'
+  ];
+
+  var templateDir = null;
+  if (context.host()) {
+    templateDir = services.path.getTemplatesPath(context.host());
+    var templateBase = path.resolve(templateDir, templatePath);
+
+    possibilities = possibilities.concat([
+      templateBase,
+      templateBase + '.html',
+      templateBase + '.htm',
+      templateBase + '/index.html',
+      templateBase + '/index.htm'
+    ]);
+  }
+
+  var matches = globby.sync(possibilities);
+
+  if (matches.length === 0 && templatePath !== '404.html') {
+    return findTemplate(context, '404.html');
+  }
+
+  if (matches.length === 0) {
+    throw new Error('Unable to find static 404 handler');
+  }
+
+  var m = matches[0].replace(defaultTemplateDir + '/', '');
+  if (templateDir) {
+    m = m.replace(templateDir + '/', '');
+  }
+  return m;
+};

--- a/src/services/template/index.js
+++ b/src/services/template/index.js
@@ -28,6 +28,11 @@ var TemplateService = {
 module.exports = TemplateService;
 
 var buildTemplateLocals = function (context, content, assets) {
+  if (assets) {
+    // Some templates still use deconst.content.assets instead of deconst.assets
+    content.assets = assets;
+  }
+
   return {
     deconst: {
       env: process.env,


### PR DESCRIPTION
Fetch global assets from the content service:
1. Explicitly from the `/assets` endpoint of the content service
2. Simultaneously with the rest of the content service requests.

Propagate them consistently to the template local context as both `deconst.content.assets` and `deconst.assets` (temporarily; see deconst/deconst-docs#201).
