### PR TITLE
Enable an optional category filter on search.

### DIFF
--- a/src/services/content/index.js
+++ b/src/services/content/index.js
@@ -114,11 +114,20 @@ var ContentService = {
       callback(null, JSON.parse(body));
     });
   },
-  getSearch: function (q, pageNumber, perPage, callback) {
+  getSearch: function (q, options, callback) {
     var searchUrl = urljoin(config.content_service_url(), 'search');
     var searchQuery = {q: q};
-    if (pageNumber !== null && pageNumber !== undefined) searchQuery.pageNumber = pageNumber;
-    if (perPage !== null && perPage !== undefined) searchQuery.perPage = perPage;
+
+    if (options.pageNumber !== null && options.pageNumber !== undefined) {
+      searchQuery.pageNumber = options.pageNumber;
+    }
+    if (options.perPage !== null && options.perPage !== undefined) {
+      searchQuery.perPage = options.perPage;
+    }
+    if (options.categories !== null && options.categories !== undefined) {
+      searchQuery.categories = options.categories;
+    }
+
     var reqStart = Date.now();
 
     logger.debug('Content service request: performing search.', {

--- a/src/services/nunjucks/index.js
+++ b/src/services/nunjucks/index.js
@@ -69,20 +69,16 @@ var createEnvironment = function (domain, loaders) {
 
     return '<pre><code>' + string + '</code></pre>';
   });
-  env.addFilter('search', function (query, pageNumber, perPage, callback) {
+  env.addFilter('search', function (query, kwargs, callback) {
     var context = this.ctx.deconst.context;
 
-    // perPage and pageNumber are optional.
-    if (!(callback instanceof Function)) {
-      callback = perPage;
-      perPage = null;
-    }
-    if (!(callback instanceof Function)) {
-      callback = pageNumber;
-      pageNumber = null;
+    // kwargs are optional.
+    if (!callback) {
+      callback = kwargs;
+      kwargs = {};
     }
 
-    ContentService.getSearch(query, pageNumber, perPage, function (err, r) {
+    ContentService.getSearch(query, kwargs.pageNumber, kwargs.perPage, function (err, r) {
       if (err) return callback(err);
 
       r.results = r.results.filter(function (each) {
@@ -91,7 +87,7 @@ var createEnvironment = function (domain, loaders) {
       });
 
       // Compute the page count as well.
-      r.pages = Math.ceil(r.total / (perPage || 10));
+      r.pages = Math.ceil(r.total / (kwargs.perPage || 10));
 
       callback(null, r);
     });

--- a/src/services/nunjucks/index.js
+++ b/src/services/nunjucks/index.js
@@ -73,12 +73,13 @@ var createEnvironment = function (domain, loaders) {
     var context = this.ctx.deconst.context;
 
     // kwargs are optional.
+    // Recognized arguments: pageNumber, perPage, categories
     if (!callback) {
       callback = kwargs;
       kwargs = {};
     }
 
-    ContentService.getSearch(query, kwargs.pageNumber, kwargs.perPage, function (err, r) {
+    ContentService.getSearch(query, kwargs, function (err, r) {
       if (err) return callback(err);
 
       r.results = r.results.filter(function (each) {

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -29,9 +29,9 @@ describe('page assembly', function () {
   it('assembles a page', function (done) {
     nock('http://content')
       .get('/control')
-      .reply(200, {
-        sha: null
-      })
+      .reply(200, { sha: null })
+      .get('/assets')
+      .reply(200, {})
       .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
       .reply(200, {
         assets: [],
@@ -47,9 +47,9 @@ describe('page assembly', function () {
   it('ignores empty URL segments', function (done) {
     nock('http://content')
       .get('/control')
-      .reply(200, {
-        sha: null
-      })
+      .reply(200, { sha: null })
+      .get('/assets')
+      .reply(200, {})
       .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Ffoo')
       .reply(200, {
         assets: [],
@@ -65,9 +65,9 @@ describe('page assembly', function () {
   it('returns the user-defined 404 template', function (done) {
     nock('http://content')
       .get('/control')
-      .reply(200, {
-        sha: null
-      })
+      .reply(200, { sha: null })
+      .get('/assets')
+      .reply(200, {})
       .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
       .reply(404);
 
@@ -80,9 +80,9 @@ describe('page assembly', function () {
   it('passes other failing status codes through', function (done) {
     nock('http://content')
       .get('/control')
-      .reply(200, {
-        sha: null
-      })
+      .reply(200, { sha: null })
+      .get('/assets')
+      .reply(200, {})
       .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
       .reply(409);
 
@@ -95,6 +95,8 @@ describe('page assembly', function () {
     nock('http://content')
       .get('/control')
       .reply(200, { sha: null })
+      .get('/assets')
+      .reply(200, {})
       .get('/search?q=term&pageNumber=3&perPage=2')
       .reply(200, {
         total: 11,
@@ -129,6 +131,8 @@ describe('page assembly', function () {
     nock('http://content')
       .get('/control')
       .reply(200, { sha: null })
+      .get('/assets')
+      .reply(200, {})
       .get('/search?q=term')
       .reply(200, {
         total: 1,
@@ -154,6 +158,8 @@ describe('page assembly', function () {
     nock('http://content')
       .get('/control')
       .reply(200, { sha: null })
+      .get('/assets')
+      .reply(200, {})
       .get('/search?q=term')
       .reply(200, {
         total: 1,
@@ -172,5 +178,31 @@ describe('page assembly', function () {
       .expect(/0: url https:\/\/deconst\.dog\/one\//)
       .expect(/0: title first/)
       .expect(/0: excerpt this <em>is<\/em> a cross-domain result/, done);
+  });
+
+  it('constrains searches by category', function (done) {
+    nock('http://content')
+      .get('/control')
+      .reply(200, { sha: null })
+      .get('/assets')
+      .reply(200, {})
+      .get('/search?q=term&categories%5B0%5D=Abyssinian&categories%5B1%5D=American%20Bobtail')
+      .reply(200, {
+        total: 1,
+        results: [
+          {
+            contentID: 'https://github.com/deconst/fake/one',
+            title: 'first',
+            excerpt: 'this <em>is</em> a constrained result'
+          }
+        ]
+      });
+
+    request(server.create())
+      .get('/searchcats/?q=term')
+      .expect(200)
+      .expect(/0: url https:\/\/deconst\.horse\/one\//)
+      .expect(/0: title first/)
+      .expect(/0: excerpt this <em>is<\/em> a constrained result/, done);
   });
 });

--- a/test/test-control/config/content.json
+++ b/test/test-control/config/content.json
@@ -3,7 +3,8 @@
         "content": {
             "/": "https://github.com/deconst/fake/",
             "/search": null,
-            "/searchparams": null
+            "/searchparams": null,
+            "/searchcats": null
         },
         "proxy": {
             "/proxy": "http://deconst.dog"

--- a/test/test-control/config/routes.json
+++ b/test/test-control/config/routes.json
@@ -3,7 +3,8 @@
         "routes": {
             "^/": "default",
             "^/search/?$": "search.html",
-            "^/searchparams/?$": "searchparams.html"
+            "^/searchparams/?$": "searchparams.html",
+            "^/searchcats/?$": "searchcats.html"
         }
     }
 }

--- a/test/test-control/templates/deconst.horse/search.html
+++ b/test/test-control/templates/deconst.horse/search.html
@@ -1,5 +1,5 @@
 {% set query = deconst.request.query -%}
-{% set r = query.notq|search(query.notpagenum, query.notperpage) -%}
+{% set r = query.notq|search(pageNumber=query.notpagenum, perPage=query.notperpage) -%}
 
 Total results: {{ r.total }}
 Number of pages: {{ r.pages }}

--- a/test/test-control/templates/deconst.horse/searchcats.html
+++ b/test/test-control/templates/deconst.horse/searchcats.html
@@ -1,0 +1,13 @@
+{% set query = deconst.request.query -%}
+{% set r = query.q|search(categories=["Abyssinian", "American Bobtail"]) -%}
+
+Total results: {{ r.total }}
+Number of pages: {{ r.pages }}
+
+{% for result in r.results %}
+{{ loop.index0 }}: url {{ result.url }}
+{{ loop.index0 }}: title {{ result.title }}
+{{ loop.index0 }}: excerpt {{ result.excerpt }}
+{% else %}
+no results
+{% endfor %}


### PR DESCRIPTION
When invoking search, allow the template designer to constrain the search request to one or more categories of content. This'll let us offer search on any particular domain to any subset of the domains that are currently hosted on Nexus - for example, we can show results from everywhere on developer.rackspace.com, but only show getcarina.com results on getcarina.com.
- [x] Convert the search filter's arguments to keyword arguments.
- [x] Accept a `categories` filter and pass it to the content service API.
- [x] Update the search documentation.
- [x] Update the deconst-docs-control search template.

The next bit of deconst/deconst-docs#187.
