### PR TITLE
Include assets on error pages

### DIFF
--- a/src/helpers/context.js
+++ b/src/helpers/context.js
@@ -9,6 +9,7 @@ function Context (req, resp) {
 
   this.contentId = null;
   this.templatePath = null;
+  this.assets = {};
 
   this.contentReqDuration = null;
   this.assetReqDuration = null;
@@ -66,6 +67,10 @@ Context.prototype.send = function (body) {
   logger.info(this._summarize(200, 'Successful request'));
 };
 
+Context.prototype.setAssets = function (assets) {
+  this.assets = assets;
+};
+
 Context.prototype.handleError = function (err) {
   var original = err;
   logger.debug(err);
@@ -74,7 +79,13 @@ Context.prototype.handleError = function (err) {
     code = 404;
   }
 
-  TemplateService.render(this, {templatePath: code.toString()}, function (err, responseBody) {
+  var options = {
+    templatePath: code.toString(),
+    assets: this.assets,
+    content: {}
+  };
+
+  TemplateService.render(this, options, function (err, responseBody) {
     if (err) {
       logger.error("I couldn't render an error template. I'm freaking out!", err);
       responseBody = "Er, I was going to render an error template, but I couldn't.";

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -67,13 +67,16 @@ describe('page assembly', function () {
       .get('/control')
       .reply(200, { sha: null })
       .get('/assets')
-      .reply(200, {})
+      .reply(200, {
+        some_css_url: 'https://cdn.wtf/hooray/main-12345.css'
+      })
       .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
       .reply(404);
 
     request(server.create())
       .get('/')
       .expect(404)
+      .expect(/https:\/\/cdn.wtf\/hooray\/main-12345.css/)
       .expect(/user-defined 404 template/, done);
   });
 

--- a/test/control-repo.js
+++ b/test/control-repo.js
@@ -83,7 +83,7 @@ describe('[control-repo] the app', function () {
     });
   });
 
-  it('returns a 404 on umnatched domains', function (done) {
+  it('returns a 404 on unmatched domains', function (done) {
     config.set({
       PRESENTED_URL_DOMAIN: 'fake-site.dev'
     });

--- a/test/helpers/before.js
+++ b/test/helpers/before.js
@@ -5,6 +5,6 @@ exports.settings = {
   CONTENT_SERVICE_URL: 'http://content',
   PRESENTED_URL_PROTO: 'https',
   PRESENTED_URL_DOMAIN: 'deconst.horse',
-  PRESENTER_LOG_LEVEL: process.env.PRESENTER_LOG_LEVEL,
+  PRESENTER_LOG_LEVEL: process.env.PRESENTER_LOG_LEVEL || 'error',
   PRESENTER_LOG_COLOR: process.env.PRESENTER_LOG_COLOR
 };

--- a/test/test-control/templates/deconst.horse/404.html
+++ b/test/test-control/templates/deconst.horse/404.html
@@ -1,1 +1,3 @@
+<pre>{{ deconst.assets.some_css_url }}</pre>
+
 <p>user-defined 404 template</p>


### PR DESCRIPTION
Unless, of course, the `/asset` query itself didn't succeed. Not much we can do there.

Fixes deconst/deconst-docs#208.
