### PR TITLE
modify JSON parsing function to read, parse, and merge many files

### DIFF
--- a/src/services/control.js
+++ b/src/services/control.js
@@ -240,8 +240,7 @@ var readAndMergeConfigFiles = function (files, def, callback) {
       var doc;
       try {
         doc = JSON.parse(body);
-      }
-      catch (e) {
+      } catch (e) {
         doc = {};
         logger.warn('Configuration file contained invalid JSON', {
           errMessage: e.message,
@@ -255,10 +254,9 @@ var readAndMergeConfigFiles = function (files, def, callback) {
       // _reasonable_ use cases.
       for (var site in doc) {
         if (doc.hasOwnProperty(site)) {
-          if(previousValue.hasOwnProperty(site)) {
+          if (previousValue.hasOwnProperty(site)) {
             previousValue[site] = previousValue[site].concat(doc[site]);
-          }
-          else {
+          } else {
             previousValue[site] = doc[site];
           }
         }

--- a/src/services/control.js
+++ b/src/services/control.js
@@ -1,7 +1,6 @@
 var fs = require('fs');
 var path = require('path');
 var async = require('async');
-var globby = require('globby');
 var npm = require('npm');
 var tmp = require('tmp');
 var childProcess = require('child_process');
@@ -327,10 +326,7 @@ var gitPull = function (repoPath, callback) {
 // Read functions
 
 var readContentMap = function (callback) {
-  var contentFiles = globby.sync([
-    PathService.getConfigPath(config.control_content_file()),
-    PathService.getConfigPath('content.d/**/*')
-  ]);
+  var contentFiles = PathService.getContentFiles();
 
   logger.debug('Beginning content map load', {
     files: contentFiles
@@ -347,10 +343,7 @@ var readContentMap = function (callback) {
 };
 
 var readTemplateMap = function (callback) {
-  var routeFiles = globby.sync([
-    PathService.getConfigPath(config.control_routes_file()),
-    PathService.getConfigPath('routes.d/**/*')
-  ]);
+  var routeFiles = PathService.getRoutesFiles();
 
   logger.debug('Begining template map load', {
     files: routeFiles
@@ -367,10 +360,7 @@ var readTemplateMap = function (callback) {
 };
 
 var readRewriteMap = function (callback) {
-  var rewriteFiles = globby.sync([
-    PathService.getConfigPath(config.control_rewrites_file()),
-    PathService.getConfigPath('rewrites.d/**/*')
-  ]);
+  var rewriteFiles = PathService.getRewritesFiles();
 
   logger.debug('Beginning rewrite map load', {
     files: rewriteFiles

--- a/src/services/control.js
+++ b/src/services/control.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 var async = require('async');
+var globby = require('globby');
 var npm = require('npm');
 var tmp = require('tmp');
 var childProcess = require('child_process');
@@ -219,30 +220,53 @@ var ControlService = {
 
 module.exports = ControlService;
 
-var maybeParseJSON = function (filename, def, callback) {
-  fs.readFile(filename, {encoding: 'utf-8'}, function (err, body) {
-    if (err) {
-      if (err.code === 'ENOENT') {
-        return callback(null, def);
+var readAndMergeConfigFiles = function (files, def, callback) {
+  // for compatibility. Might be called with files as a single path, not an
+  // array of paths
+  if (!Array.isArray(files)) {
+    files = [files];
+  }
+
+  async.reduce(files, {}, function (previousValue, currentValue, reduceCallback) {
+    fs.readFile(currentValue, {encoding: 'utf-8'}, function (err, body) {
+      if (err) {
+        if (err.code === 'ENOENT') {
+          return callback(null, def);
+        }
+
+        return callback(err);
       }
 
-      return callback(err);
-    }
+      var doc;
+      try {
+        doc = JSON.parse(body);
+      }
+      catch (e) {
+        doc = {};
+        logger.warn('Configuration file contained invalid JSON', {
+          errMessage: e.message,
+          filename: currentValue,
+          source: body
+        });
+      }
 
-    var doc;
-    try {
-      doc = JSON.parse(body);
-    } catch (e) {
-      logger.warn('Configuration file contained invalid JSON', {
-        errMessage: e.message,
-        filename: filename,
-        source: body
-      });
+      // I'm surprised this little concatenation loop works as well as it does.
+      // Could definitely use some testing to be sure it covers all the
+      // _reasonable_ use cases.
+      for (var site in doc) {
+        if (doc.hasOwnProperty(site)) {
+          if(previousValue.hasOwnProperty(site)) {
+            previousValue[site] = previousValue[site].concat(doc[site]);
+          }
+          else {
+            previousValue[site] = doc[site];
+          }
+        }
+      }
 
-      return callback(e);
-    }
-    callback(null, doc);
-  });
+      reduceCallback(null, previousValue);
+    });
+  }, callback);
 };
 
 var subdirectories = function (rootPath, callback) {
@@ -305,49 +329,62 @@ var gitPull = function (repoPath, callback) {
 // Read functions
 
 var readContentMap = function (callback) {
-  var contentMapPath = PathService.getConfigPath(config.control_content_file());
+  var contentFiles = globby.sync([
+    PathService.getConfigPath(config.control_content_file()),
+    PathService.getConfigPath('content.d/**/*')
+  ]);
+
   logger.debug('Beginning content map load', {
-    filename: contentMapPath
+    files: contentFiles
   });
 
-  maybeParseJSON(contentMapPath, {}, function (err, contentMap) {
+  readAndMergeConfigFiles(contentFiles, {}, function (err, contentMap) {
     if (err) return callback(err);
 
     logger.debug('Successfully loaded content map', {
-      filename: contentMapPath
+      files: contentFiles
     });
     callback(null, contentMap);
   });
 };
 
 var readTemplateMap = function (callback) {
-  var templateMapPath = PathService.getConfigPath(config.control_routes_file());
+  var routeFiles = globby.sync([
+    PathService.getConfigPath(config.control_routes_file()),
+    PathService.getConfigPath('routes.d/**/*')
+  ]);
+
   logger.debug('Begining template map load', {
-    filename: templateMapPath
+    files: routeFiles
   });
 
-  maybeParseJSON(templateMapPath, {}, function (err, templateMap) {
+  readAndMergeConfigFiles(routeFiles, {}, function (err, templateMap) {
     if (err) return callback(err);
 
     logger.debug('Successfully loaded template map', {
-      filename: templateMapPath
+      filename: routeFiles
     });
     callback(null, templateMap);
   });
 };
 
 var readRewriteMap = function (callback) {
-  var rewriteMapPath = PathService.getConfigPath(config.control_rewrites_file());
+  var rewriteFiles = globby.sync([
+    PathService.getConfigPath(config.control_rewrites_file()),
+    PathService.getConfigPath('rewrites.d/**/*')
+  ]);
+
   logger.debug('Beginning rewrite map load', {
-    filename: rewriteMapPath
+    files: rewriteFiles
   });
 
-  maybeParseJSON(rewriteMapPath, {}, function (err, rewriteMap) {
+  readAndMergeConfigFiles(rewriteFiles, {}, function (err, rewriteMap) {
     if (err) return callback(err);
 
     logger.debug('Successfully loaded rewrite map', {
-      filename: rewriteMapPath
+      files: rewriteFiles
     });
+
     callback(null, rewriteMap);
   });
 };

--- a/src/services/path.js
+++ b/src/services/path.js
@@ -1,5 +1,7 @@
 var path = require('path');
+var globby = require('globby');
 var config = require('../config');
+
 
 var CONFIG_PATH = 'config';
 
@@ -28,6 +30,36 @@ var PathService = {
   getConfigPath: function (configPath) {
     configPath = configPath || '';
     return path.resolve(this.getControlRepoPath(), CONFIG_PATH, configPath);
+  },
+  getContentFiles: function () {
+    if(process.env.CONTROL_CONTENT_FILE) {
+      return globby.sync([this.getConfigPath(process.env.CONTROL_CONTENT_FILE)]);
+    }
+
+    return globby.sync([
+      this.getConfigPath(config.control_content_file()),
+      this.getConfigPath('content.d/**/*')
+    ]);
+  },
+  getRewritesFiles: function () {
+    if(process.env.CONTROL_REWRITES_FILE) {
+      return globby.sync([this.getConfigPath(process.env.CONTROL_REWRITES_FILE)]);
+    }
+
+    return globby.sync([
+      this.getConfigPath(config.control_rewrites_file()),
+      this.getConfigPath('rewrites.d/**/*')
+    ]);
+  },
+  getRoutesFiles: function () {
+    if(process.env.CONTROL_ROUTES_FILE) {
+      return globby.sync([this.getConfigPath(process.env.CONTROL_ROUTES_FILE)]);
+    }
+
+    return globby.sync([
+      this.getConfigPath(config.control_routes_file()),
+      this.getConfigPath('routes.d/**/*')
+    ]);
   }
 };
 

--- a/src/services/path.js
+++ b/src/services/path.js
@@ -2,7 +2,6 @@ var path = require('path');
 var globby = require('globby');
 var config = require('../config');
 
-
 var CONFIG_PATH = 'config';
 
 var PathService = {
@@ -32,7 +31,7 @@ var PathService = {
     return path.resolve(this.getControlRepoPath(), CONFIG_PATH, configPath);
   },
   getContentFiles: function () {
-    if(process.env.CONTROL_CONTENT_FILE) {
+    if (process.env.CONTROL_CONTENT_FILE) {
       return globby.sync([this.getConfigPath(process.env.CONTROL_CONTENT_FILE)]);
     }
 
@@ -42,7 +41,7 @@ var PathService = {
     ]);
   },
   getRewritesFiles: function () {
-    if(process.env.CONTROL_REWRITES_FILE) {
+    if (process.env.CONTROL_REWRITES_FILE) {
       return globby.sync([this.getConfigPath(process.env.CONTROL_REWRITES_FILE)]);
     }
 
@@ -52,7 +51,7 @@ var PathService = {
     ]);
   },
   getRoutesFiles: function () {
-    if(process.env.CONTROL_ROUTES_FILE) {
+    if (process.env.CONTROL_ROUTES_FILE) {
       return globby.sync([this.getConfigPath(process.env.CONTROL_ROUTES_FILE)]);
     }
 


### PR DESCRIPTION
This addresses the desire to support multiple config files as described in https://github.com/deconst/presenter/issues/89.

I'm using a little glob to support multiple config files without explicitly requiring them:

``` javascript
var rewriteFiles = globby.sync([
    PathService.getConfigPath(config.control_rewrites_file()),
    PathService.getConfigPath('rewrites.d/**/*')
]);
```

Then, I modified the `maybeParseJSON` helper function to reduce all of the config files into one big config object, allowing all the other internals to stay exactly the way they are right now.
