### PR TITLE
[WIP] Handle the control repo overhaul

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,8 +13,8 @@ var logger = require('./src/server/logging').logger;
 
 var ControlService = require('./src/services/control');
 
-ControlService.update(null, function (ok) {
-  if (!ok) {
+ControlService.update(function (err) {
+  if (err) {
     logger.warn('Unable to perform initial control repository load');
   }
 

--- a/src/control-repo.js
+++ b/src/control-repo.js
@@ -1,5 +1,145 @@
-// Since the control repo is just an NPM package, we could technically just
-// `npm install` it.
-var ControlRepo = require(process.env.CONTROL_REPO_PATH);
+var fs = require('fs');
+var path = require('path');
+var spawn = require('child_process').spawn;
+
+var async = require('async');
+var npm = require('npm');
+
+var logger = require('./server/logging').logger;
+
+var NPMInstallInProgress = false;
+
+
+var NPMUtils = {
+  getInstance: function (callback) {
+    return npm.load({}, callback);
+  },
+  cleanCache: function (callback) {
+    logger.debug('Cleaning control repo module from NPM cache', {
+      moduleName: process.env.CONTROL_REPO_MODULE_NAME
+    });
+
+    this.getInstance(function (err, npm) {
+      npm.commands.cache(['clean', process.env.CONTROL_REPO_MODULE_NAME], callback);
+    });
+  }
+};
+
+var RequireUtils = {
+  cleanCache: function (callback) {
+    logger.debug('Cleaning control repo and children from CommonJS module cache', {
+      moduleName: process.env.CONTROL_REPO_MODULE_NAME
+    });
+
+    // Invalidate the cache for the control repo and all of its children
+    var ControlRepoPath = path.resolve(require.resolve(process.env.CONTROL_REPO_MODULE_NAME), '..');
+    var controlRepoModulePaths = [ControlRepoPath];
+
+    async.waterfall([
+      function (callback) {
+        fs.readFile(path.resolve(ControlRepoPath, 'package.json'), 'utf-8', callback);
+      },
+      function (file, callback) {
+        var jsonDocument;
+        try {
+          jsonDocument = JSON.parse(file);
+        } catch (e) {
+          return callback(e);
+        }
+
+        for(var moduleName in jsonDocument.dependencies) {
+          controlRepoModulePaths.push(path.resolve(require.resolve(moduleName), '..'));
+        }
+
+        return callback(null);
+      }
+    ], function (err, result) {
+      var pathStartsWithAny = function (path, prefixes) {
+        var match = false;
+        Array.prototype.forEach.call(prefixes, function (prefix) {
+          if(path.indexOf(prefix) === 0) {
+            match = true;
+          }
+        });
+
+        return match;
+      };
+
+      var modulesToCacheBust = [];
+      for(var moduleName in require.cache) {
+        if(pathStartsWithAny(moduleName, controlRepoModulePaths)) {
+          modulesToCacheBust.push(moduleName);
+        }
+      }
+
+      logger.debug('Clearing cached control repo modules', {
+        modules: modulesToCacheBust
+      });
+      
+      modulesToCacheBust.forEach(function (module) {
+        delete require.cache[module];
+      });
+
+      return callback(err);
+    });
+  }
+};
+
+var ControlRepo = {
+  loaded: function () {
+    try {
+      require.resolve(process.env.CONTROL_REPO_MODULE_NAME);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  },
+  // We want this to be as idempotent as possible
+  reload: function (callback) {
+    callback = callback || function () {};
+    var startTime = Date.now();
+    logger.debug('Beginning control repo reload', {});
+
+    async.waterfall([
+      function (callback) {
+        if(NPMInstallInProgress) {
+          return callback('NPM Install already in progress');
+        }
+
+        NPMInstallInProgress = true;
+        logger.debug('Running npm install ' + process.env.CONTROL_REPO_MODULE);
+        var npmInstall = spawn('npm', ['install', process.env.CONTROL_REPO_MODULE]);
+
+        npmInstall.on('close', function (code) {
+          NPMInstallInProgress = false;
+          if(code !== 0) {
+            return callback('npm install exited with code ' + code);
+          }
+
+          return callback(null);
+        });
+      },
+      function (callback) {
+        return RequireUtils.cleanCache(arguments[arguments.length - 1]);
+      }
+    ], function (err, result) {
+      if (err) {
+        logger.warn('Control repo reload aborted', {
+          error: err,
+          duration: Date.now() - startTime
+        });
+      } else {
+        logger.debug('Finished control repo reload', {
+          duration: Date.now() - startTime
+        });
+      }
+
+      return callback(err, result);
+    });
+  },
+  getInstance: function () {
+    return require(process.env.CONTROL_REPO_MODULE_NAME);
+  }
+};
 
 module.exports = ControlRepo;

--- a/src/control-repo.js
+++ b/src/control-repo.js
@@ -1,0 +1,5 @@
+// Since the control repo is just an NPM package, we could technically just
+// `npm install` it.
+var ControlRepo = require(process.env.CONTROL_REPO_PATH);
+
+module.exports = ControlRepo;

--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -111,17 +111,19 @@ module.exports = function (req, res) {
         return callback(null, toc.envelope.body);
       });
     },
-    control: function (callback) {
-      ContentService.getControlSHA(context, function (err, sha) {
-        if (err) return callback(err);
-
-        // No need to hold up the current request for the control repository update.
-        // Kick it off here but don't wait for it to complete.
-        if (sha && sha !== ControlService.getControlSHA()) ControlService.update(sha);
-
-        callback(null, sha);
-      });
-    }
+    // control: function (callback) {
+    //   ContentService.getControlSHA(context, function (err, sha) {
+    //     if (err) return callback(err);
+    //
+    //     // No need to hold up the current request for the control repository update.
+    //     // Kick it off here but don't wait for it to complete.
+    //     if (sha && sha !== ControlService.getControlSHA()) {
+    //       ControlService.update(sha);
+    //     }
+    //
+    //     callback(null, sha);
+    //   });
+    // }
   }, function (err, output) {
     if (err || capturedError) {
       return context.handleError(err || capturedError);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -8,13 +8,20 @@ var logging = require('./logging');
 var proxies = require('./proxies');
 var rewrites = require('./rewrites');
 var routes = require('../routers');
+var config = require('../config');
 
 var PathService = require('../services/path');
 
 exports.create = function () {
   var app = express();
 
-  app.use('/assets', express.static(PathService.getAssetPath()));
+  // Serve assets from the appropriate site in the control repo
+  app.use('/assets', function (req, res, next) {
+    var domain = config.presented_url_domain() || req.hostname;
+    var assetsPath = PathService.getAssetPath(domain);
+
+    return express.static(assetsPath).apply(this, arguments);
+  });
 
   app.use(logging.requestLogger());
   app.set('trust proxy', true);

--- a/src/server/proxies.js
+++ b/src/server/proxies.js
@@ -24,6 +24,16 @@ function makeProxyRoute (site, path, target) {
 module.exports = function (app) {
   var proxies = ContentRoutingService.getAllProxies();
 
+  // This __local_asset__ path is returned when the content service is memory-backed.
+  // This little patch probably belongs over there, but I'm here right now so
+  // this will do for now.
+  // See also: https://github.com/deconst/content-service/issues/66
+  app.use('/__local_asset__', makeProxyRoute(
+    config.presented_url_domain(),
+    '__local_asset__/',
+    url.resolve(config.content_service_url(), '/assets')
+  ));
+
   proxies.forEach(function (each) {
     for (var path in each.proxy) {
       app.use(path + '*', makeProxyRoute(each.site, path, each.proxy[path]));

--- a/src/server/proxies.js
+++ b/src/server/proxies.js
@@ -6,9 +6,11 @@ var request = require('request');
 
 function makeProxyRoute (site, path, target) {
   return function (req, res, next) {
-    var host = config.presented_url_domain() || req.get('Host');
-    if (host !== site) {
-      return next();
+    if(site) {
+      var host = config.presented_url_domain() || req.get('Host');
+      if (host !== site) {
+        return next();
+      }
     }
 
     var suffix = url.parse(req.originalUrl).path.replace(path, '');
@@ -29,7 +31,7 @@ module.exports = function (app) {
   // this will do for now.
   // See also: https://github.com/deconst/content-service/issues/66
   app.use('/__local_asset__', makeProxyRoute(
-    config.presented_url_domain(),
+    null,
     '__local_asset__/',
     url.resolve(config.content_service_url(), '/assets')
   ));

--- a/src/services/control.js
+++ b/src/services/control.js
@@ -2,7 +2,6 @@ var fs = require('fs');
 var path = require('path');
 var async = require('async');
 var npm = require('npm');
-var tmp = require('tmp');
 var childProcess = require('child_process');
 var mkdirp = require('mkdirp');
 
@@ -21,12 +20,9 @@ var lastAttemptSHA = null;
 var updateInProgress = false;
 var cachePath = null;
 
-/**
- * @todo This file is way too long. All the git stuff needs to be somewhere else.
- */
-
-var ControlService = {
+var ControlRepoUpdater = {
   load: function (callback) {
+    callback = callback || function () {};
     var startTs = Date.now();
     logger.info('Loading control repository');
 
@@ -38,7 +34,7 @@ var ControlService = {
           duration: Date.now() - startTs
         });
 
-        return callback(false);
+        return callback(new Error('Unable to bootstrap nunjucks templates.'));
       }
 
       async.parallel({
@@ -55,7 +51,7 @@ var ControlService = {
             duration: Date.now() - startTs
           });
 
-          return callback(false);
+          return callback(new Error('Unable to load control repository.'));
         }
 
         ContentRoutingService.setContentMap(result.contentMap);
@@ -80,205 +76,56 @@ var ControlService = {
           duration: Date.now() - startTs
         });
 
-        callback(true);
+        callback(null);
       });
     });
   },
-  update: function (sha, callback) {
+  update: function (callback) {
     // The callback is optional.
     if (!callback) {
       callback = function () {};
     }
 
     if (updateInProgress) {
-      return callback(false);
-    }
-
-    var startTs = Date.now();
-    logger.info('Updating control repository', {
-      sha: sha
-    });
-
-    if (sha !== null && lastAttemptSHA === sha) {
-      logger.info('Skipping load of already-attempted SHA', {
-        sha: sha,
-        lastAttemptSHA: lastAttemptSHA
-      });
-      return callback(false);
-    }
-    lastAttemptSHA = sha;
-
-    var isGit = !!config.control_repo_url();
-    var shouldUpdate = (sha === null) || (sha !== controlSHA);
-
-    if (!shouldUpdate) {
-      logger.info('Control repository SHA is already up to date.', {
-        sha: sha
-      });
-
-      return callback(false);
+      return callback(new Error('Control Repo update already in progress'), null);
     }
 
     updateInProgress = true;
 
-    var handleErr = function (err) {
-      logger.error('Unable to update control repository', {
-        errMessage: err.message,
-        stack: err.stack,
-        sha: sha
-      });
-
-      updateInProgress = false;
-      callback(false);
-    };
-
-    var gitStartTs = null;
-    var gitCompletePayload = null;
-
-    var andLoad = function (err, newSHA) {
-      if (err) return handleErr(err);
-
-      if (gitStartTs !== null && gitCompletePayload !== null) {
-        gitCompletePayload.duration = Date.now() - gitStartTs;
-        var msg = gitCompletePayload.message;
-        delete gitCompletePayload.message;
-
-        logger.info(msg, gitCompletePayload);
-      }
-
-      /**
-       * @todo The signature for this function should be function (err, result)
-       */
-      this.load(function (ok) {
-        if (ok) {
-          logger.info('Control repository update complete.', {
-            fromSHA: controlSHA,
-            toSHA: newSHA,
-            duration: Date.now() - startTs
-          });
-
-          controlSHA = newSHA;
-        } else {
-          logger.error('Control repository load failed.', {
-            currentSHA: controlSHA,
-            toSHA: sha
-          });
-        }
-
+    // Do something to determine whether a reload is necessary.
+    ControlRepo.reload(function (err) {
+      ControlRepoUpdater.load(function (err) {
         updateInProgress = false;
-        callback(ok);
+        callback(err);
       });
-    }.bind(this);
-
-    if (isGit) {
-      var parentPath = path.dirname(PathService.getControlRepoPath());
-
-      mkdirp(parentPath, function (err) {
-        if (err) return handleErr(err);
-
-        fs.readdir(PathService.getControlRepoPath(), function (err, contents) {
-          if (err) {
-            if (err.code === 'ENOENT') {
-              // New repository.
-
-              logger.debug('Beginning control repository clone', {
-                url: config.control_repo_url(),
-                branch: config.control_repo_branch()
-              });
-              gitCompletePayload = {
-                message: 'Completed control repository clone',
-                url: config.control_repo_url(),
-                branch: config.control_repo_branch()
-              };
-              gitStartTs = Date.now();
-
-              gitClone(
-                config.control_repo_url(),
-                config.control_repo_branch(),
-                PathService.getControlRepoPath(),
-                andLoad);
-              return;
-            }
-
-            return handleErr(err);
-          }
-
-          // Existing repository.
-          logger.debug('Beginning control repository pull');
-          gitCompletePayload = {message: 'Completed control repository pull'};
-          gitStartTs = Date.now();
-
-          gitPull(
-            PathService.getControlRepoPath(),
-            andLoad);
-        });
-      });
-    } else {
-      // Non-git repository. Most likely a local mount.
-      logger.debug('Skipping update for non-git control repository.');
-
-      return andLoad(null, 'non-git');
-    }
-  },
-  getControlSHA: function () {
-    return controlSHA;
+    });
   }
 };
 
-module.exports = ControlService;
+module.exports = ControlRepoUpdater;
 
-var readCurrentSHA = function (repoPath, callback) {
-  return function (err, stdout, stderr) {
-    if (err) {
-      err.stdout = stdout;
-      err.stderr = stderr;
-      return callback(err);
-    }
+/**
+ * @todo This interval is not how we want to check for control repo updates.
+ */
+setInterval(function () {
+  ControlRepoUpdater.update(function () {
+    ControlRepoUpdater.load(function (err) {
+      updateInProgress = false;
+    });
+  });
+}, 60000);
 
-    childProcess.execFile(
-      '/usr/bin/git',
-      ['rev-parse', 'HEAD'],
-      {cwd: repoPath},
-      function (err, stdout, stderr) {
-        if (err) {
-          err.stdout = stdout;
-          err.stderr = stderr;
-          return callback(err);
-        }
 
-        callback(null, stdout.replace(/\r?\n$/, ''));
-      }
-    );
-  };
-};
-
-var gitClone = function (url, branch, repoPath, callback) {
-  childProcess.execFile(
-    '/usr/bin/git',
-    ['clone', '--branch', branch, url, repoPath],
-    readCurrentSHA(repoPath, callback)
-  );
-};
-
-var gitPull = function (repoPath, callback) {
-  childProcess.execFile(
-    '/usr/bin/git',
-    ['pull'],
-    {cwd: repoPath},
-    readCurrentSHA(repoPath, callback)
-  );
-};
 
 // Read functions
-
 var readContentMap = function (callback) {
-  ControlRepo.getContentMaps(function (err, maps) {
-    if(err) {
+  ControlRepo.getInstance().getContentMaps(function (err, maps) {
+    if (err) {
       return callback(err, null);
     }
 
     logger.debug('Successfully loaded content maps', {
-      maps: maps
+      // maps: maps
     });
 
     callback(err, maps);
@@ -286,13 +133,13 @@ var readContentMap = function (callback) {
 };
 
 var readTemplateMap = function (callback) {
-  ControlRepo.getRouteMaps(function (err, maps) {
-    if(err) {
+  ControlRepo.getInstance().getRouteMaps(function (err, maps) {
+    if (err) {
       return callback(err, null);
     }
 
     logger.debug('Successfully loaded template maps', {
-      maps: maps
+      // maps: maps
     });
 
     callback(err, maps);
@@ -300,13 +147,13 @@ var readTemplateMap = function (callback) {
 };
 
 var readRewriteMap = function (callback) {
-  ControlRepo.getRewriteMaps(function (err, maps) {
-    if(err) {
+  ControlRepo.getInstance().getRewriteMaps(function (err, maps) {
+    if (err) {
       return callback(err, null);
     }
 
     logger.debug('Successfully loaded rewrite maps', {
-      maps: maps
+      // maps: maps
     });
 
     callback(err, maps);
@@ -319,7 +166,7 @@ var loadPlugins = function (callback) {
 
   var allPlugins = {};
 
-  async.each(ControlRepo.sites, function (site, cb) {
+  async.each(ControlRepo.getInstance().sites, function (site, cb) {
     site.getPlugins(function (err, plugins) {
       allPlugins[site.domain] = plugins;
       return cb();
@@ -339,7 +186,7 @@ var loadTemplates = function (callback) {
 
   var sources = {};
 
-  async.each(ControlRepo.sites, function (site, cb) {
+  async.each(ControlRepo.getInstance().sites, function (site, cb) {
     site.getTemplateSources(function (err, templateSources) {
       createAtomicLoader(templateSources, function (err, loader) {
         sources[site.domain] = loader;

--- a/src/services/nunjucks/atomic-loader.js
+++ b/src/services/nunjucks/atomic-loader.js
@@ -4,68 +4,16 @@ var walk = require('walk');
 
 var logger = require('../../server/logging').logger;
 
-var AtomicLoader = function (basePath, templateFiles) {
-  this.templateSources = {};
-
-  var templatePaths = Object.keys(templateFiles);
-
-  for (var i = 0; i < templatePaths.length; i++) {
-    var templateName = templatePaths[i];
-    var templateSource = templateFiles[templateName];
-    var templateFullPath = path.resolve(basePath, templateName);
-
-    if (templateFullPath.indexOf(basePath) === -1) {
-      logger.warn('Attempt to load template outside of base path', {
-        basePath: basePath,
-        templateName: templateName,
-        templatePath: templateFullPath
-      });
-      continue;
-    }
-
-    this.templateSources[templateName] = {
-      src: templateSource,
-      path: templateFullPath,
-      noCache: this.noCache
-    };
-  }
+var AtomicLoader = function (templateSources) {
+  this.templateSources = templateSources;
 };
 
 AtomicLoader.prototype.getSource = function (name) {
   return this.templateSources[name] || null;
 };
 
-var createAtomicLoader = function (rootPath, callback) {
-  if (!/\/$/.test(rootPath)) {
-    rootPath += '/';
-  }
-
-  var templateFiles = {};
-  var walker = walk.walk(rootPath, {followLinks: false});
-
-  walker.on('file', function (root, stat, next) {
-    var fullPath = path.join(root, stat.name);
-    var templateName = fullPath.replace(rootPath, '');
-
-    fs.readFile(fullPath, {encoding: 'utf-8'}, function (err, body) {
-      if (err) {
-        logger.warn('Unable to read template file', {
-          templatePath: fullPath,
-          errMessage: err.message,
-          stack: err.stack
-        });
-
-        return next();
-      }
-
-      templateFiles[templateName] = body;
-      next();
-    });
-  });
-
-  walker.on('end', function () {
-    callback(null, new AtomicLoader(rootPath, templateFiles));
-  });
+var createAtomicLoader = function (templateSources, callback) {
+  return callback(null, new AtomicLoader(templateSources));
 };
 
 module.exports = createAtomicLoader;

--- a/src/services/path.js
+++ b/src/services/path.js
@@ -16,16 +16,16 @@ var PathService = {
     return path.resolve(this.getControlRepoPath(), 'plugins');
   },
   getPluginsPath: function (domain) {
-    return ControlRepo.getPluginsPath(domain);
+    return ControlRepo.getInstance().getPluginsPath(domain);
   },
   getTemplatesRoot: function (domain) {
     return path.resolve(this.getControlRepoPath(), 'templates');
   },
   getTemplatesPath: function (domain) {
-    return ControlRepo.getTemplatesPath(domain);
+    return ControlRepo.getInstance().getTemplatesPath(domain);
   },
   getAssetPath: function (domain) {
-    return ControlRepo.getAssetsPath(domain);
+    return ControlRepo.getInstance().getAssetsPath(domain);
   },
   getConfigPath: function (configPath) {
     configPath = configPath || '';

--- a/src/services/path.js
+++ b/src/services/path.js
@@ -24,8 +24,8 @@ var PathService = {
   getTemplatesPath: function (domain) {
     return ControlRepo.getTemplatesPath(domain);
   },
-  getAssetPath: function () {
-    return path.resolve(PathService.getControlRepoPath(), 'assets');
+  getAssetPath: function (domain) {
+    return ControlRepo.getAssetsPath(domain);
   },
   getConfigPath: function (configPath) {
     configPath = configPath || '';

--- a/src/services/path.js
+++ b/src/services/path.js
@@ -1,6 +1,7 @@
 var path = require('path');
 var globby = require('globby');
 var config = require('../config');
+var ControlRepo = require('../control-repo');
 
 var CONFIG_PATH = 'config';
 
@@ -15,13 +16,13 @@ var PathService = {
     return path.resolve(this.getControlRepoPath(), 'plugins');
   },
   getPluginsPath: function (domain) {
-    return path.resolve(this.getPluginsRoot(), domain);
+    return ControlRepo.getPluginsPath(domain);
   },
   getTemplatesRoot: function (domain) {
     return path.resolve(this.getControlRepoPath(), 'templates');
   },
   getTemplatesPath: function (domain) {
-    return path.resolve(this.getTemplatesRoot(), domain);
+    return ControlRepo.getTemplatesPath(domain);
   },
   getAssetPath: function () {
     return path.resolve(PathService.getControlRepoPath(), 'assets');

--- a/src/services/rewrite.js
+++ b/src/services/rewrite.js
@@ -11,7 +11,7 @@ var RewriteService = {
     };
 
     for (var domain in configMap) {
-      configMap[domain].forEach(compileRx);
+      Array.prototype.forEach.call(configMap[domain], compileRx);
     }
 
     rewriteMap = configMap;

--- a/src/services/rewrite.js
+++ b/src/services/rewrite.js
@@ -18,6 +18,10 @@ var RewriteService = {
   },
   getRewrite: function (req) {
     var domain = config.presented_url_domain() || req.get('Host');
+    if(!rewriteMap[domain]) {
+      return;
+    }
+
     var rewrites = rewriteMap[domain].rewrites || [];
 
     for (var i = 0; i < rewrites.length; i++) {

--- a/src/services/rewrite.js
+++ b/src/services/rewrite.js
@@ -11,14 +11,14 @@ var RewriteService = {
     };
 
     for (var domain in configMap) {
-      Array.prototype.forEach.call(configMap[domain], compileRx);
+      Array.prototype.forEach.call(configMap[domain].rewrites, compileRx);
     }
 
     rewriteMap = configMap;
   },
   getRewrite: function (req) {
     var domain = config.presented_url_domain() || req.get('Host');
-    var rewrites = rewriteMap[domain] || [];
+    var rewrites = rewriteMap[domain].rewrites || [];
 
     for (var i = 0; i < rewrites.length; i++) {
       var rule = rewrites[i];

--- a/src/services/template/index.js
+++ b/src/services/template/index.js
@@ -3,6 +3,7 @@ var path = require('path');
 var NunjucksService = require('../nunjucks');
 var PathService = require('../path');
 var UrlService = require('../url');
+var ControlRepo = require('../../control-repo');
 
 var TemplateService = {
   render: function (context, options, callback) {
@@ -58,7 +59,7 @@ var findTemplate = function (context, templatePath) {
   ];
 
   var templateDir = null;
-  if (context.host()) {
+  if (context.host() && ControlRepo.siteExists(context.host())) {
     templateDir = PathService.getTemplatesPath(context.host());
     var templateBase = path.resolve(templateDir, templatePath);
 

--- a/src/services/template/index.js
+++ b/src/services/template/index.js
@@ -59,7 +59,7 @@ var findTemplate = function (context, templatePath) {
   ];
 
   var templateDir = null;
-  if (context.host() && ControlRepo.siteExists(context.host())) {
+  if (context.host() && ControlRepo.getInstance().siteExists(context.host())) {
     templateDir = PathService.getTemplatesPath(context.host());
     var templateBase = path.resolve(templateDir, templatePath);
 

--- a/static/404.html
+++ b/static/404.html
@@ -10,6 +10,6 @@
         <h1>Page Not Found</h1>
         <p>Sorry, the page you requested does not exist.</p>
     </div>
-    <span id="footer">Powered by <a href="https://github.com/deconst/deconst">deconst</a></span>
+    <span id="footer">Powered by <a href="https://github.com/deconst">deconst</a></span>
 </body>
 </html>

--- a/static/500.html
+++ b/static/500.html
@@ -10,6 +10,6 @@
         <h1>System Error</h1>
         <p>Sorry, a system error has prevented this page from being shown correctly.</p>
     </div>
-    <span id="footer">Powered by <a href="https://github.com/deconst/deconst">deconst</a></span>
+    <span id="footer">Powered by <a href="https://github.com/deconst">deconst</a></span>
 </body>
 </html>


### PR DESCRIPTION
Since the control repo is getting its own code, we can offload a lot of the nasty plumbing and directory crawling work to that module, and just interact with the control repo via a (hopefully) concise API. The control repo's API is still very much in flux, but this PR reflects the changes I'm making to keep the presenter working as the control repo changes.
