### PR TITLE
Send 500 when things go really bad in Express

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -25,6 +25,7 @@ exports.create = function () {
 
   app.use(function (err, req, res, next) {
     logging.logger.error({
+      statusCode: 500,
       stack: err.stack,
       message: 'Express.js error handler invoked'
     });


### PR DESCRIPTION
This should make these errors a little easier to spot in the logs.
