### PR TITLE
Staging mode

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,1 +1,0 @@
-node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: false
 node_js:
 - "4.2.1"
 install:
-- npm install -g jshint
 - npm install .
 script:
 - npm test
-- jshint .

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^0.9.0",
+    "cheerio": "^0.20.0",
     "express": "4.12.3",
     "globby": "^2.0.0",
     "handlebars": "3.0.0",

--- a/src/config.js
+++ b/src/config.js
@@ -79,6 +79,13 @@ var configuration = {
     env: 'PRESENTER_DIAGNOSTICS',
     description: 'Enable diagnostic tooling within the presenter.',
     required: false
+  },
+  staging_mode: {
+    env: 'STAGING_MODE',
+    description: 'Present staged content from many revisions at subpaths.',
+    normalize: normalize_bool,
+    def: 'false',
+    required: false
   }
 };
 

--- a/src/helpers/context.js
+++ b/src/helpers/context.js
@@ -2,7 +2,7 @@
 
 const logger = require('../server/logging').logger;
 const config = require('../config');
-const ContentRoutingService = require('../services/routing');
+const ContentRoutingService = require('../services/content/routing');
 const TemplateService = require('../services/template');
 
 function Context (req, resp) {

--- a/src/helpers/context.js
+++ b/src/helpers/context.js
@@ -1,6 +1,9 @@
-var logger = require('../server/logging').logger;
-var config = require('../config');
-var TemplateService = require('../services/template');
+'use strict';
+
+const logger = require('../server/logging').logger;
+const config = require('../config');
+const ContentRoutingService = require('../services/routing');
+const TemplateService = require('../services/template');
 
 function Context (req, resp) {
   this.request = req;
@@ -14,12 +17,36 @@ function Context (req, resp) {
   this.contentReqDuration = null;
   this.assetReqDuration = null;
   this.templateRenderDuration = null;
+
+  if (config.staging_mode()) {
+    this._applyStagingMode();
+  }
 }
+
+Context.prototype._applyStagingMode = function () {
+  this.originalPresentedPath = this.request.path;
+
+  let parts = this.request.path.split('/');
+  while (parts[0] === '') {
+    parts.shift();
+  }
+
+  let first = parts.shift();
+  if (ContentRoutingService.isKnownDomain(first)) {
+    this.stagingHost = first;
+    this.revisionID = parts.shift();
+  } else {
+    this.stagingHost = config.presented_url_domain();
+    this.revisionID = first;
+  }
+
+  this.stagingPresentedPath = '/' + parts.join('/');
+};
 
 Context.prototype._summarize = function (statusCode, message, err) {
   var summary = {
-    statusCode: statusCode,
-    message: message,
+    statusCode,
+    message,
     requestURL: this.request.url,
     requestDomain: this.host(),
     requestProtocol: this.protocol(),
@@ -46,6 +73,14 @@ Context.prototype._summarize = function (statusCode, message, err) {
     summary.templateRenderDuration = this.templateRenderDuration;
   }
 
+  if (this.revisionID) {
+    summary.revisionID = this.revisionID;
+  }
+
+  if (this.stagingPresentedPath) {
+    summary.stagingPresentedPath = this.stagingPresentedPath;
+  }
+
   if (err) {
     summary.errMessage = err.message;
     summary.stack = err.stack;
@@ -54,8 +89,12 @@ Context.prototype._summarize = function (statusCode, message, err) {
   return summary;
 };
 
+Context.prototype.presentedPath = function () {
+  return this.stagingPresentedPath || this.request.path;
+};
+
 Context.prototype.host = function () {
-  return config.presented_url_domain() || this.request.get('Host');
+  return this.stagingHost || config.presented_url_domain() || this.request.get('Host');
 };
 
 Context.prototype.protocol = function () {

--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -74,9 +74,12 @@ ContentFilterService.add(function (input, next) {
         //   return;
         // }
 
-        if (parts[0] === '') {
-          parts.shift();
+        if (parts[0] !== '') {
+          // URL is a non-root-relative URL.
+          return;
         }
+
+        parts.shift();
         parts.unshift(context.revisionID);
 
         if (targetURL.hostname) {

--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -1,15 +1,16 @@
+'use strict';
 // Handler to assemble a specific piece of static content.
 
-var async = require('async');
-var logger = require('../server/logging').logger;
-var Context = require('../helpers/context');
-var TemplateService = require('../services/template');
-var TemplateRoutingService = require('../services/template/routing');
-var ContentService = require('../services/content');
-var ContentRoutingService = require('../services/content/routing');
-var ContentFilterService = require('../services/content/filter');
-var UrlService = require('../services/url');
-var ControlService = require('../services/control');
+const async = require('async');
+const logger = require('../server/logging').logger;
+const Context = require('../helpers/context');
+const TemplateService = require('../services/template');
+const TemplateRoutingService = require('../services/template/routing');
+const ContentService = require('../services/content');
+const ContentRoutingService = require('../services/content/routing');
+const ContentFilterService = require('../services/content/filter');
+const UrlService = require('../services/url');
+const ControlService = require('../services/control');
 
 // Register content filters.
 

--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -69,10 +69,10 @@ ContentFilterService.add(function (input, next) {
         let targetURL = url.parse(target);
         let parts = targetURL.pathname.split('/');
 
-        // if (targetURL.hostname && !ContentRoutingService.isKnownDomain(targetURL.hostname)) {
-        //   // URL is an absolute URL to a non-cluster destination.
-        //   return;
-        // }
+        if (targetURL.hostname && !ContentRoutingService.isKnownDomain(targetURL.hostname)) {
+          // URL is an absolute URL to a non-cluster destination.
+          return;
+        }
 
         if (parts[0] !== '') {
           // URL is a non-root-relative URL.

--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -1,7 +1,10 @@
 'use strict';
 // Handler to assemble a specific piece of static content.
 
+const url = require('url');
 const async = require('async');
+const cheerio = require('cheerio');
+const config = require('../config');
 const logger = require('../server/logging').logger;
 const Context = require('../helpers/context');
 const TemplateService = require('../services/template');
@@ -15,12 +18,12 @@ const ControlService = require('../services/control');
 // Register content filters.
 
 ContentFilterService.add(function (input, next) {
-  var context = input.context;
-  var content = input.content;
+  let context = input.context;
+  let content = input.content;
 
   // Match nunjucks-like "{{ to('') }}" directives that are used to defer rendering of presented URLs
   // until presenter-time.
-  var urlDirectiveRx = /\{\{\s*to\('([^']+)'\)\s*\}\}/g;
+  let urlDirectiveRx = /\{\{\s*to\('([^']+)'\)\s*\}\}/g;
 
   if (content.contentID && content.envelope) {
     // Replace any "{{ to() }}" directives with the appropriate presented URL.
@@ -36,8 +39,8 @@ ContentFilterService.add(function (input, next) {
 });
 
 ContentFilterService.add(function (input, next) {
-  var context = input.context;
-  var content = input.content;
+  let context = input.context;
+  let content = input.content;
 
   // Locate the URLs for the content IDs of any next and previous links included in the
   // document.
@@ -47,6 +50,49 @@ ContentFilterService.add(function (input, next) {
 
   if (content.previous && content.previous.contentID && !content.previous.url) {
     content.previous.url = ContentRoutingService.getPresentedUrl(context, content.previous.contentID);
+  }
+
+  return next();
+});
+
+ContentFilterService.add(function (input, next) {
+  if (config.staging_mode()) {
+    let context = input.context;
+    let body = input.content.envelope.body;
+
+    let $ = cheerio.load(body);
+
+    $('a').each((i, element) => {
+      let e = $(element);
+      let target = e.attr('href');
+      if (target) {
+        let targetURL = url.parse(target);
+        let parts = targetURL.pathname.split('/');
+
+        // if (targetURL.hostname && !ContentRoutingService.isKnownDomain(targetURL.hostname)) {
+        //   // URL is an absolute URL to a non-cluster destination.
+        //   return;
+        // }
+
+        if (parts[0] === '') {
+          parts.shift();
+        }
+        parts.unshift(context.revisionID);
+
+        let shouldUnshiftHost = false;
+        shouldUnshiftHost = shouldUnshiftHost || context.host() !== config.presented_url_domain();
+        if (shouldUnshiftHost) {
+          parts.unshift(context.host());
+          logger.debug('unshifted host!');
+        }
+
+        targetURL.pathname = '/' + parts.join('/');
+
+        e.attr('href', url.format(targetURL));
+      }
+    });
+
+    input.content.envelope.body = $.html();
   }
 
   return next();

--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -79,11 +79,20 @@ ContentFilterService.add(function (input, next) {
         }
         parts.unshift(context.revisionID);
 
-        let shouldUnshiftHost = false;
-        shouldUnshiftHost = shouldUnshiftHost || context.host() !== config.presented_url_domain();
-        if (shouldUnshiftHost) {
+        if (targetURL.hostname) {
+          // URL is an absolute URL to an on-cluster destination.
+          if (targetURL.hostname !== config.presented_url_domain()) {
+            parts.unshift(targetURL.hostname);
+          }
+
+          targetURL.protocol = null;
+          targetURL.slashes = false;
+          targetURL.host = null;
+          targetURL.hostname = null;
+        } else if (context.host() !== config.presented_url_domain()) {
+          // URL is a root-relative URL and the current staging host is non-default.
+
           parts.unshift(context.host());
-          logger.debug('unshifted host!');
         }
 
         targetURL.pathname = '/' + parts.join('/');

--- a/src/services/content/routing.js
+++ b/src/services/content/routing.js
@@ -47,6 +47,9 @@ var ContentRoutingService = {
   setContentMap: function (map) {
     contentMap = map;
   },
+  isKnownDomain: function (domain) {
+    return contentMap[domain] !== undefined;
+  },
   getContentId: function (context, urlPath) {
     urlPath = urlPath || context.request.path;
     var domainContentMap = getDomainContentMap(context.host());

--- a/src/services/template/routing.js
+++ b/src/services/template/routing.js
@@ -18,7 +18,7 @@ var TemplateRoutingService = {
     templateMap = map;
   },
   getRoute: function (context) {
-    var urlPath = context.request.path;
+    var urlPath = context.presentedPath();
     var domainTemplateMap = getDomainTemplateMap(context.host());
     var bestMatch = null;
 

--- a/test/config.js
+++ b/test/config.js
@@ -1,11 +1,13 @@
-/* globals it describe */
+'use strict';
+/* globals it describe afterEach */
 // Unit tests for the configuration system.
 
-var expect = require('chai').expect;
-var config = require('../src/config');
+const expect = require('chai').expect;
+const config = require('../src/config');
+const before = require('./helpers/before');
 
-describe('config', function () {
-  it('reads configuration values from the environment', function () {
+describe('config', () => {
+  it('reads configuration values from the environment', () => {
     config.configure({
       CONTROL_REPO_PATH: './test/test-control',
       CONTENT_SERVICE_URL: 'https://content',
@@ -13,7 +15,8 @@ describe('config', function () {
       PRESENTED_URL_DOMAIN: 'deconst.horse',
       PUBLIC_URL_PROTO: 'https',
       PUBLIC_URL_DOMAIN: 'localhost',
-      PRESENTER_LOG_LEVEL: 'debug'
+      PRESENTER_LOG_LEVEL: 'debug',
+      STAGING_MODE: 'true'
     });
 
     expect(config.content_service_url()).to.equal('https://content');
@@ -22,15 +25,16 @@ describe('config', function () {
     expect(config.public_url_proto()).to.equal('https');
     expect(config.public_url_domain()).to.equal('localhost');
     expect(config.log_level()).to.equal('debug');
+    expect(config.staging_mode()).to.equal(true);
   });
 
-  it('requires service URLs', function () {
-    expect(function () {
+  it('requires service URLs', () => {
+    expect(() => {
       config.configure({});
     }).to.throw(Error, /Inadequate configuration/);
   });
 
-  it('defaults the log level', function () {
+  it('defaults the log level', () => {
     config.configure({
       CONTROL_REPO_PATH: './test/test-control',
       CONTENT_SERVICE_URL: 'https://content'
@@ -39,7 +43,7 @@ describe('config', function () {
     expect(config.log_level()).to.equal('info');
   });
 
-  it('normalizes service URLs', function () {
+  it('normalizes service URLs', () => {
     config.configure({
       CONTROL_REPO_PATH: './test/test-control',
       CONTENT_SERVICE_URL: 'https://content/'
@@ -47,4 +51,6 @@ describe('config', function () {
 
     expect(config.content_service_url()).to.equal('https://content');
   });
+
+  afterEach(before.reconfigure);
 });

--- a/test/content-routing.js
+++ b/test/content-routing.js
@@ -1,22 +1,19 @@
+'use strict';
 /* globals it describe beforeEach */
 // Unit tests for the ContentRoutingService.
 
-var before = require('./helpers/before');
-var config = require('../src/config');
-var expect = require('chai').expect;
+const before = require('./helpers/before');
+const expect = require('chai').expect;
 
-config.configure(before.settings);
+const ContentRoutingService = require('../src/services/content/routing');
 
-var ContentRoutingService = require('../src/services/content/routing');
-
-describe('ContentRoutingService', function () {
+describe('ContentRoutingService', () => {
   var context = {
-    host: function () {
-      return 'deconst.horse';
-    }
+    host: () => 'deconst.horse'
   };
 
-  beforeEach(function () {
+  beforeEach(before.reconfigure);
+  beforeEach(() => {
     ContentRoutingService.setContentMap({
       'deconst.horse': {
         content: {
@@ -30,10 +27,16 @@ describe('ContentRoutingService', function () {
     });
   });
 
+  it('recognizes a known domain', () => {
+    expect(ContentRoutingService.isKnownDomain('deconst.horse')).to.equal(true);
+  });
+
+  it('recognizes an unknown domain', () => {
+    expect(ContentRoutingService.isKnownDomain('other.horse')).to.equal(false);
+  });
+
   var shouldMap = function (presentedPath, contentID) {
-    return function () {
-      expect(ContentRoutingService.getContentId(context, presentedPath)).to.equal(contentID);
-    };
+    return () => expect(ContentRoutingService.getContentId(context, presentedPath)).to.equal(contentID);
   };
 
   it('returns a sentinel for umapped content',

--- a/test/helpers/before.js
+++ b/test/helpers/before.js
@@ -1,10 +1,19 @@
+'use strict';
 // Common setup functions for unit tests.
 
-exports.settings = {
+const config = require('../../src/config');
+
+const settings = {
   CONTROL_REPO_PATH: './test/test-control',
   CONTENT_SERVICE_URL: 'http://content',
   PRESENTED_URL_PROTO: 'https',
   PRESENTED_URL_DOMAIN: 'deconst.horse',
   PRESENTER_LOG_LEVEL: process.env.PRESENTER_LOG_LEVEL || 'error',
   PRESENTER_LOG_COLOR: process.env.PRESENTER_LOG_COLOR
+};
+
+exports.settings = settings;
+
+exports.reconfigure = function () {
+  config.configure(settings);
 };

--- a/test/helpers/before.js
+++ b/test/helpers/before.js
@@ -1,6 +1,7 @@
 'use strict';
 // Common setup functions for unit tests.
 
+const _ = require('lodash');
 const config = require('../../src/config');
 
 const settings = {
@@ -16,4 +17,11 @@ exports.settings = settings;
 
 exports.reconfigure = function () {
   config.configure(settings);
+};
+
+exports.reconfigureWith = function (overrides) {
+  return () => {
+    let s = _.defaults(overrides, settings);
+    config.configure(s);
+  };
 };

--- a/test/staging.js
+++ b/test/staging.js
@@ -94,7 +94,7 @@ describe('staging mode', () => {
       request(server.create())
         .get('/build-12345/subpath/')
         .expect(200)
-        .expect(/<a href="https:\/\/deconst\.horse\/build-12345\/huh\/what\/">/, done);
+        .expect(/<a href="\/build-12345\/huh\/what\/">/, done);
     });
 
     it('prepends host and revision ID to outgoing root-relative links for non-default hosts', (done) => {

--- a/test/staging.js
+++ b/test/staging.js
@@ -1,0 +1,64 @@
+'use strict';
+/* globals it describe beforeEach afterEach */
+// Unit tests to exercise staging mode
+
+const before = require('./helpers/before');
+const config = require('../src/config');
+
+config.configure(before.settings);
+
+const request = require('supertest');
+const nock = require('nock');
+const server = require('../src/server');
+const ControlService = require('../src/services/control');
+
+describe('staging mode', () => {
+  beforeEach(before.reconfigureWith({
+    PRESENTED_URL_DOMAIN: 'deconst.horse',
+    STAGING_MODE: 'true'
+  }));
+  beforeEach((done) => {
+    ControlService.load((ok) => {
+      if (!ok) return done(new Error('Control repository load failed'));
+      done();
+    });
+  });
+
+  it('understands the host and revision ID path segments', (done) => {
+    nock('http://content')
+      .get('/control')
+      .reply(200, { sha: null })
+      .get('/assets')
+      .reply(200, {})
+      .get('/content/https%3A%2F%2Fgithub.com%2Fbuild-12345%2Fdeconst%2Ffake%2Fsubpath')
+      .reply(200, {
+        assets: [],
+        envelope: { body: 'subpath content' }
+      });
+
+    request(server.create())
+      .get('/build-12345/subpath/')
+      .expect(200)
+      .expect(/subpath content/, done);
+  });
+
+  it('recognizes a non-default host path segment', (done) => {
+    nock('http://content')
+      .get('/control')
+      .reply(200, { sha: null })
+      .get('/assets')
+      .reply(200, {})
+      .get('/content/https%3A%2F%2Fgithub.com%2Fbuild-12345%2Fdeconst-dog%2Ffake%2Fand-how')
+      .reply(200, {
+        assets: [],
+        envelope: { body: 'deconst dog content' }
+      });
+
+    request(server.create())
+      .get('/deconst.dog/build-12345/and-how/')
+      .expect(200)
+      .expect(/deconst dog content/, done);
+  });
+
+  afterEach(before.reconfigure);
+});

--- a/test/staging.js
+++ b/test/staging.js
@@ -24,7 +24,7 @@ describe('staging mode', () => {
     });
   });
 
-  it('understands the host and revision ID path segments', (done) => {
+  it('understands the revision ID path segment', (done) => {
     nock('http://content')
       .get('/control')
       .reply(200, { sha: null })

--- a/test/test-control/config/routes.json
+++ b/test/test-control/config/routes.json
@@ -6,5 +6,10 @@
             "^/searchparams/?$": "searchparams.html",
             "^/searchcats/?$": "searchcats.html"
         }
+    },
+    "deconst.dog": {
+        "routes": {
+            ".": "default.html"
+        }
     }
 }

--- a/test/test-control/templates/deconst.dog/default.html
+++ b/test/test-control/templates/deconst.dog/default.html
@@ -1,0 +1,2 @@
+<h1><code>default.html in deconst.dog</code></h1>
+{{ deconst.content.envelope.body }}


### PR DESCRIPTION
When `STAGING_MODE` is active:
- Remember the actual presented path as the _original presented path_. Trim the first path segment from the presented path.
- If it matches one of the configured domains in the control repository, pop it from the path and override the _Host_, then pop the next path segment as the _revision ID_. Otherwise, set the _Host_ to the "default" staging site and stash the path segment as the _revision ID_. Remember the modified presented path as the _modified presented path_.
- Use the _modified presented path_ to locate a content ID prefix and to route to a template.
- Assemble the content ID from the content ID prefix. Re-inject the _revision ID_ as its first path segment.
- Rewrite outgoing links to include initial _Host_ and _revision ID_ segments.

Fixes #97.
