### PR TITLE
Implement a mapping API.

### DIFF
--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -1,9 +1,11 @@
+'use strict';
 // Dispatch requests to handlers.
 
-var version = require('./version');
-var content = require('./content');
-var crash = require('./crash');
-var config = require('../config');
+const version = require('./version');
+const content = require('./content');
+const crash = require('./crash');
+const mappings = require('./mappings');
+const config = require('../config');
 
 exports.install = function (app) {
   if (config.presenter_diagnostics()) {
@@ -11,5 +13,6 @@ exports.install = function (app) {
   }
 
   app.get('/version', version);
+  app.get('/_api/whereis/:id', mappings.whereis);
   app.get('/*', content);
 };

--- a/src/routers/mappings.js
+++ b/src/routers/mappings.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const ContentRoutingService = require('../services/content/routing');
+
+exports.whereis = function (req, res) {
+  let contentID = req.params.id;
+  let mappings = ContentRoutingService.getMappingsForContentID(contentID);
+
+  res.json({ mappings });
+};

--- a/src/services/content/routing.js
+++ b/src/services/content/routing.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const url = require('url');
+const urlJoin = require('url-join');
 const config = require('../../config');
 const logger = require('../../server/logging').logger;
 const UrlService = require('../url');
@@ -100,6 +101,8 @@ var ContentRoutingService = {
       for (let basePath in domainContent.map) {
         let baseContentID = domainContent.map[basePath];
         if (baseContentID === null) continue;
+
+        // Normalize the baseContentID without a trailing slash so the .replace() works correctly.
         baseContentID = baseContentID.replace(/\/$/, '');
 
         if (contentID.indexOf(baseContentID) !== -1) {
@@ -107,9 +110,9 @@ var ContentRoutingService = {
 
           mappings.push({
             domain: domainContent.domain,
-            baseContentID,
+            baseContentID: `${baseContentID}/`,
             basePath,
-            subPath
+            path: urlJoin(basePath, subPath)
           });
 
           if (onlyFirst) break;
@@ -129,8 +132,7 @@ var ContentRoutingService = {
     }
 
     let urls = this.getMappingsForContentID(contentID, domain, onlyFirst).map((mapping) => {
-      let path = url.resolve(mapping.basePath, mapping.subPath);
-      return UrlService.getSiteUrl(context, path, mapping.domain);
+      return UrlService.getSiteUrl(context, mapping.path, mapping.domain);
     });
 
     if (urls.length === 0) return null;

--- a/test/api-mapping.js
+++ b/test/api-mapping.js
@@ -29,7 +29,7 @@ describe('the mapping API', () => {
           mappings: [
             {
               domain: 'deconst.horse',
-              path: '/subrepo/somepath/',
+              path: '/subrepo/somepath',
               baseContentID: 'https://github.com/deconst/subrepo/',
               basePath: '/subrepo/'
             }

--- a/test/api-mapping.js
+++ b/test/api-mapping.js
@@ -2,13 +2,78 @@
 /* globals it describe beforeEach */
 
 const before = require('./helpers/before');
+const config = require('../src/config');
+
+config.configure(before.settings);
+
+const request = require('supertest');
+const server = require('../src/server');
+const ControlService = require('../src/services/control');
 
 describe('the mapping API', () => {
   beforeEach(before.reconfigure);
+  beforeEach((done) => {
+    ControlService.load((ok) => {
+      if (!ok) return done(new Error('Control repository load failed'));
+      done();
+    });
+  });
 
   describe('/_api/whereis', () => {
-    it('returns the domain and paths of a content ID');
-    it('returns multiple results for redundantly mapped content');
-    it('returns an empty collection for unknown content IDs');
+    it('returns the domain and paths of a content ID', (done) => {
+      request(server.create())
+        .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fdeconst%2Fsubrepo%2Fsomepath')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .expect({
+          mappings: [
+            {
+              domain: 'deconst.horse',
+              path: '/subrepo/somepath/',
+              baseContentID: 'https://github.com/deconst/subrepo/',
+              basePath: '/subrepo/'
+            }
+          ]
+        }, done);
+    });
+
+    it('returns multiple results for redundantly mapped content', (done) => {
+      request(server.create())
+        .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fdeconst%2Fredundant')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .expect({
+          mappings: [
+            {
+              domain: 'deconst.horse',
+              path: '/redundant/',
+              baseContentID: 'https://github.com/deconst/redundant/',
+              basePath: '/redundant/'
+            },
+            {
+              domain: 'deconst.horse',
+              path: '/multimapped/',
+              baseContentID: 'https://github.com/deconst/redundant/',
+              basePath: '/multimapped/'
+            },
+            {
+              domain: 'deconst.dog',
+              path: '/elsewhere/',
+              baseContentID: 'https://github.com/deconst/redundant/',
+              basePath: '/elsewhere/'
+            }
+          ]
+        }, done);
+    });
+
+    it('returns an empty collection for unknown content IDs', (done) => {
+      request(server.create())
+        .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fnope%2Fnope')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .expect({
+          mappings: []
+        }, done);
+    });
   });
 });

--- a/test/api-mapping.js
+++ b/test/api-mapping.js
@@ -1,0 +1,14 @@
+'use-strict';
+/* globals it describe beforeEach */
+
+const before = require('./helpers/before');
+
+describe('the mapping API', () => {
+  beforeEach(before.reconfigure);
+
+  describe('/_api/whereis', () => {
+    it('returns the domain and paths of a content ID');
+    it('returns multiple results for redundantly mapped content');
+    it('returns an empty collection for unknown content IDs');
+  });
+});

--- a/test/test-control/config/content.json
+++ b/test/test-control/config/content.json
@@ -2,9 +2,12 @@
     "deconst.horse": {
         "content": {
             "/": "https://github.com/deconst/fake/",
-            "/search": null,
-            "/searchparams": null,
-            "/searchcats": null
+            "/subrepo/": "https://github.com/deconst/subrepo/",
+            "/redundant/": "https://github.com/deconst/redundant/",
+            "/multimapped/": "https://github.com/deconst/redundant/",
+            "/search/": null,
+            "/searchparams/": null,
+            "/searchcats/": null
         },
         "proxy": {
             "/proxy": "http://deconst.dog"
@@ -12,7 +15,8 @@
     },
     "deconst.dog": {
         "content": {
-            "/": "https://github.com/deconst-dog/fake/"
+            "/": "https://github.com/deconst-dog/fake/",
+            "/elsewhere/": "https://github.com/deconst/redundant/"
         }
     }
 }


### PR DESCRIPTION
Implement an API that allows clients to query the content map. This'll keep me from needing to reimplement control repository parsing everywhere.

Fixes #103.
