### PR TITLE
Account for revision ID in the mapping API

### DIFF
--- a/src/services/content/routing.js
+++ b/src/services/content/routing.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const url = require('url');
 const urlJoin = require('url-join');
 const config = require('../../config');
 const logger = require('../../server/logging').logger;
 const UrlService = require('../url');
+const RevisionService = require('../revision');
 
 var contentMap = {};
 
@@ -57,15 +57,7 @@ var ContentRoutingService = {
 
     // In staging mode, prepend a path segment with the revision ID into the content ID.
     if (config.staging_mode()) {
-      let u = url.parse(contentID);
-      let pathSegments = u.pathname.split('/');
-      while (pathSegments[0] === '') {
-        pathSegments.shift();
-      }
-      pathSegments.unshift(context.revisionID);
-      u.pathname = pathSegments.join('/');
-
-      contentID = url.format(u);
+      contentID = RevisionService.applyToContentID(context.revisionID, contentID);
     }
 
     return contentID;

--- a/src/services/revision.js
+++ b/src/services/revision.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const url = require('url');
+const config = require('../config');
+
+// Lazily loaded because of the circular dependency.
+let ContentRoutingService = null;
+
+let RevisionService = {
+  fromPath: function (path) {
+    if (!ContentRoutingService) {
+      ContentRoutingService = require('./content/routing');
+    }
+
+    let stagingHost = null;
+    let stagingPresentedPath = null;
+    let revisionID = null;
+
+    let parts = path.split('/');
+    while (parts[0] === '') {
+      parts.shift();
+    }
+
+    let first = parts.shift();
+    if (ContentRoutingService.isKnownDomain(first)) {
+      stagingHost = first;
+      revisionID = parts.shift();
+    } else {
+      stagingHost = config.presented_url_domain();
+      revisionID = first;
+    }
+    stagingPresentedPath = '/' + parts.join('/');
+
+    return { revisionID, stagingHost, stagingPresentedPath };
+  },
+  applyToContentID: function (revisionID, contentID) {
+    let u = url.parse(contentID);
+    let pathSegments = u.pathname.split('/');
+    while (pathSegments[0] === '') {
+      pathSegments.shift();
+    }
+    pathSegments.unshift(revisionID);
+    u.pathname = pathSegments.join('/');
+
+    return url.format(u);
+  }
+};
+
+module.exports = RevisionService;

--- a/src/services/revision.js
+++ b/src/services/revision.js
@@ -33,15 +33,31 @@ let RevisionService = {
 
     return { revisionID, stagingHost, stagingPresentedPath };
   },
-  applyToContentID: function (revisionID, contentID) {
+  fromContentID: function (contentID) {
     let u = url.parse(contentID);
-    let pathSegments = u.pathname.split('/');
+
+    let parts = u.pathname.split('/');
+    while (parts[0] === '') {
+      parts.shift();
+    }
+
+    let revisionID = parts.shift();
+    u.pathname = '/' + parts.join('/');
+    contentID = url.format(u);
+
+    return { revisionID, contentID };
+  },
+  applyToPath: function (revisionID, path) {
+    let pathSegments = path.split('/');
     while (pathSegments[0] === '') {
       pathSegments.shift();
     }
     pathSegments.unshift(revisionID);
-    u.pathname = pathSegments.join('/');
-
+    return '/' + pathSegments.join('/');
+  },
+  applyToContentID: function (revisionID, contentID) {
+    let u = url.parse(contentID);
+    u.pathname = this.applyToPath(revisionID, u.pathname);
     return url.format(u);
   }
 };

--- a/test/staging.js
+++ b/test/staging.js
@@ -201,7 +201,7 @@ describe('staging mode', () => {
 
   it('includes revision IDs in /_api/whereis', (done) => {
     request(server.create())
-      .get('/_api/whereis/https://github.com/build-1234/deconst/subrepo/foo/')
+      .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fbuild-1234%2Fdeconst%2Fsubrepo%2Ffoo%2F')
       .set('Accept', 'application/json')
       .expect(200)
       .expect({

--- a/test/staging.js
+++ b/test/staging.js
@@ -199,5 +199,20 @@ describe('staging mode', () => {
     });
   });
 
+  it('includes revision IDs in /_api/whereis', (done) => {
+    request(server.create())
+      .get('/_api/whereis/https://github.com/build-1234/deconst/subrepo/foo/')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .expect({
+        mappings: [ {
+          domain: 'deconst.horse',
+          baseContentID: 'https://github.com/build-1234/deconst/subrepo/',
+          basePath: '/build-1234/subrepo/',
+          path: '/build-1234/subrepo/foo/'
+        } ]
+      }, done);
+  });
+
   afterEach(before.reconfigure);
 });


### PR DESCRIPTION
In staging mode, account for revision IDs in the `/_api/whereis` endpoint.
