### PR TITLE
Include non-default domain segments in mapping API

### DIFF
--- a/src/services/content/routing.js
+++ b/src/services/content/routing.js
@@ -109,15 +109,16 @@ var ContentRoutingService = {
         baseContentID = baseContentID.replace(/\/$/, '');
 
         if (contentID.indexOf(baseContentID) !== -1) {
+          let domain = domainContent.domain;
           let subPath = contentID.replace(baseContentID, '');
 
           if (config.staging_mode()) {
             baseContentID = RevisionService.applyToContentID(revisionID, baseContentID);
-            basePath = RevisionService.applyToPath(revisionID, basePath);
+            basePath = RevisionService.applyToPath(revisionID, domain, basePath);
           }
 
           mappings.push({
-            domain: domainContent.domain,
+            domain,
             baseContentID: `${baseContentID}/`,
             basePath,
             path: urlJoin(basePath, subPath)

--- a/src/services/revision.js
+++ b/src/services/revision.js
@@ -37,7 +37,7 @@ let RevisionService = {
     let u = url.parse(contentID);
 
     let parts = u.pathname.split('/');
-    while (parts[0] === '') {
+    if (parts[0] === '') {
       parts.shift();
     }
 
@@ -47,17 +47,22 @@ let RevisionService = {
 
     return { revisionID, contentID };
   },
-  applyToPath: function (revisionID, path) {
+  applyToPath: function (revisionID, domain, path) {
     let pathSegments = path.split('/');
-    while (pathSegments[0] === '') {
+    if (pathSegments[0] === '') {
       pathSegments.shift();
     }
+
     pathSegments.unshift(revisionID);
+    if (domain && domain !== config.presented_url_domain()) {
+      pathSegments.unshift(domain);
+    }
+
     return '/' + pathSegments.join('/');
   },
   applyToContentID: function (revisionID, contentID) {
     let u = url.parse(contentID);
-    u.pathname = this.applyToPath(revisionID, u.pathname);
+    u.pathname = this.applyToPath(revisionID, null, u.pathname);
     return url.format(u);
   }
 };

--- a/test/staging.js
+++ b/test/staging.js
@@ -215,7 +215,20 @@ describe('staging mode', () => {
         }, done);
     });
 
-    it('includes non-default host segments');
+    it('includes non-default host segments', (done) => {
+      request(server.create())
+        .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fbuild-abc%2Fdeconst-dog%2Ffake%2F')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .expect({
+          mappings: [ {
+            domain: 'deconst.dog',
+            baseContentID: 'https://github.com/build-abc/deconst-dog/fake/',
+            basePath: '/deconst.dog/build-abc/',
+            path: '/deconst.dog/build-abc/'
+          } ]
+        }, done);
+    });
   });
 
   afterEach(before.reconfigure);

--- a/test/staging.js
+++ b/test/staging.js
@@ -199,19 +199,23 @@ describe('staging mode', () => {
     });
   });
 
-  it('includes revision IDs in /_api/whereis', (done) => {
-    request(server.create())
-      .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fbuild-1234%2Fdeconst%2Fsubrepo%2Ffoo%2F')
-      .set('Accept', 'application/json')
-      .expect(200)
-      .expect({
-        mappings: [ {
-          domain: 'deconst.horse',
-          baseContentID: 'https://github.com/build-1234/deconst/subrepo/',
-          basePath: '/build-1234/subrepo/',
-          path: '/build-1234/subrepo/foo/'
-        } ]
-      }, done);
+  describe('/_api/whereis', () => {
+    it('includes revision IDs in mappings', (done) => {
+      request(server.create())
+        .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fbuild-1234%2Fdeconst%2Fsubrepo%2Ffoo%2F')
+        .set('Accept', 'application/json')
+        .expect(200)
+        .expect({
+          mappings: [ {
+            domain: 'deconst.horse',
+            baseContentID: 'https://github.com/build-1234/deconst/subrepo/',
+            basePath: '/build-1234/subrepo/',
+            path: '/build-1234/subrepo/foo/'
+          } ]
+        }, done);
+    });
+
+    it('includes non-default host segments');
   });
 
   afterEach(before.reconfigure);


### PR DESCRIPTION
When necessary, include a domain segment in the mappings API response. We'll need this to correctly generate URLs to preview content hosted on non-default domains.
