### PR TITLE
Never index staging presenter contents

### DIFF
--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -5,6 +5,7 @@ const version = require('./version');
 const content = require('./content');
 const crash = require('./crash');
 const mappings = require('./mappings');
+const robots = require('./robots');
 const config = require('../config');
 
 exports.install = function (app) {
@@ -14,5 +15,6 @@ exports.install = function (app) {
 
   app.get('/version', version);
   app.get('/_api/whereis/:id', mappings.whereis);
+  app.get('/robots.txt', robots);
   app.get('/*', content);
 };

--- a/src/routers/robots.js
+++ b/src/routers/robots.js
@@ -1,0 +1,14 @@
+'use strict';
+// Hardcode the robots.txt for staging servers. For production servers, fall through to the normal
+// content flow.
+
+const config = require('../config');
+const content = require('./content');
+
+module.exports = function (req, res) {
+  if (!config.staging_mode()) {
+    return content(req, res);
+  }
+
+  res.send('User-agent: *\nDisallow: /\n');
+};

--- a/src/routers/robots.js
+++ b/src/routers/robots.js
@@ -10,5 +10,6 @@ module.exports = function (req, res) {
     return content(req, res);
   }
 
+  res.set('Content-type', 'text/plain');
   res.send('User-agent: *\nDisallow: /\n');
 };

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -208,4 +208,19 @@ describe('page assembly', function () {
       .expect(/0: title first/)
       .expect(/0: excerpt this <em>is<\/em> a constrained result/, done);
   });
+
+  it('renders a real robots.txt', (done) => {
+    nock('http://content')
+      .get('/control').reply(200, { sha: null })
+      .get('/assets').reply(200, {})
+      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Frobots.txt')
+      .reply(200, {
+        envelope: { body: 'not hardcoded' }
+      });
+
+    request(server.create())
+      .get('/robots.txt')
+      .expect(200)
+      .expect(/not hardcoded/, done);
+  });
 });

--- a/test/staging.js
+++ b/test/staging.js
@@ -232,7 +232,12 @@ describe('staging mode', () => {
   });
 
   describe('robots.txt', () => {
-    it('always denies everything');
+    it('always denies everything', (done) => {
+      request(server.create())
+        .get('/robots.txt')
+        .expect(200)
+        .expect('User-agent: *\nDisallow: /\n', done);
+    });
   });
 
   afterEach(before.reconfigure);

--- a/test/staging.js
+++ b/test/staging.js
@@ -231,5 +231,9 @@ describe('staging mode', () => {
     });
   });
 
+  describe('robots.txt', () => {
+    it('always denies everything');
+  });
+
   afterEach(before.reconfigure);
 });

--- a/test/staging.js
+++ b/test/staging.js
@@ -236,6 +236,7 @@ describe('staging mode', () => {
       request(server.create())
         .get('/robots.txt')
         .expect(200)
+        .expect('Content-type', 'text/plain; charset=utf-8')
         .expect('User-agent: *\nDisallow: /\n', done);
     });
   });


### PR DESCRIPTION
In staging mode, hardcode a `robots.txt` that asks crawlers to not index staging sites.

Fixes #107.
