### PR TITLE
Deterministic template search path

### DIFF
--- a/src/services/template/index.js
+++ b/src/services/template/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
 const NunjucksService = require('../nunjucks');

--- a/src/services/template/index.js
+++ b/src/services/template/index.js
@@ -1,8 +1,8 @@
-var globby = require('globby');
-var path = require('path');
-var NunjucksService = require('../nunjucks');
-var PathService = require('../path');
-var UrlService = require('../url');
+const fs = require('fs');
+const path = require('path');
+const NunjucksService = require('../nunjucks');
+const PathService = require('../path');
+const UrlService = require('../url');
 
 var TemplateService = {
   render: function (context, options, callback) {
@@ -71,17 +71,26 @@ var findTemplate = function (context, templatePath) {
     ]);
   }
 
-  var matches = globby.sync(possibilities);
+  let match = null;
 
-  if (matches.length === 0 && templatePath !== '404.html') {
+  for (var i = 0; i < possibilities.length; i++) {
+    let possibility = possibilities[i];
+    let exists = fs.accessSync(possibility, fs.R_OK);
+
+    if (exists) {
+      match = possibility;
+    }
+  }
+
+  if (match === null && templatePath !== '404.html') {
     return findTemplate(context, '404.html');
   }
 
-  if (matches.length === 0) {
+  if (match === null) {
     throw new Error('Unable to find static 404 handler');
   }
 
-  var m = matches[0].replace(defaultTemplateDir + '/', '');
+  var m = match.replace(defaultTemplateDir + '/', '');
   if (templateDir) {
     m = m.replace(templateDir + '/', '');
   }

--- a/src/services/template/index.js
+++ b/src/services/template/index.js
@@ -77,10 +77,13 @@ var findTemplate = function (context, templatePath) {
 
   for (var i = 0; i < possibilities.length; i++) {
     let possibility = possibilities[i];
-    let exists = fs.accessSync(possibility, fs.R_OK);
+    try {
+      fs.accessSync(possibility, fs.R_OK);
 
-    if (exists) {
+      // possibility is an existing path
       match = possibility;
+    } catch (e) {
+      // possibility does not exist or is inaccessible
     }
   }
 


### PR DESCRIPTION
I strongly suspect that our 404 page woes are caused by globby returning results in a somewhat nondeterministic order. This is on production:

``` node
let ps = ['/usr/src/app/static/404',
  '/usr/src/app/static/404.html',
  '/usr/src/app/static/404.htm',
  '/usr/src/app/static/404/index.html',
  '/usr/src/app/static/404/index.htm',
  '/tmp/control-repo/templates/developer.rackspace.com/404',
  '/tmp/control-repo/templates/developer.rackspace.com/404.html',
  '/tmp/control-repo/templates/developer.rackspace.com/404.htm',
  '/tmp/control-repo/templates/developer.rackspace.com/404/index.html',
  '/tmp/control-repo/templates/developer.rackspace.com/404/index.htm']
globby.sync(ps)
[ '/usr/src/app/static/404.html',
  '/tmp/control-repo/templates/developer.rackspace.com/404.html' ]
```

Notice that we take `matches[0]` in the source, which is actually wrong for 404 templates if we assume that globby _does_ preserve order: the control repository-provided custom 404 page's path will occur _later_. I can't verify it, but I'm guessing that occasionally, the results in `matches` are in the opposite order, hence production flapping between the two.

To be safe I'm taking out the globbing in favor of `fs` calls and explicit, predictable ordering.

This might fix #109 unless it doesn't.
