### PR TITLE
Avoid Nunjucks loader re-use

### DIFF
--- a/src/services/control.js
+++ b/src/services/control.js
@@ -1,19 +1,21 @@
-var fs = require('fs');
-var path = require('path');
-var async = require('async');
-var npm = require('npm');
-var tmp = require('tmp');
-var childProcess = require('child_process');
-var mkdirp = require('mkdirp');
+'use strict';
 
-var config = require('../config');
-var logger = require('../server/logging').logger;
-var PathService = require('./path');
-var ContentRoutingService = require('./content/routing');
-var TemplateRoutingService = require('./template/routing');
-var RewriteService = require('./rewrite');
-var NunjucksService = require('./nunjucks');
-var createAtomicLoader = require('./nunjucks/atomic-loader');
+const fs = require('fs');
+const path = require('path');
+const async = require('async');
+const npm = require('npm');
+const tmp = require('tmp');
+const childProcess = require('child_process');
+const mkdirp = require('mkdirp');
+
+const config = require('../config');
+const logger = require('../server/logging').logger;
+const PathService = require('./path');
+const ContentRoutingService = require('./content/routing');
+const TemplateRoutingService = require('./template/routing');
+const RewriteService = require('./rewrite');
+const NunjucksService = require('./nunjucks');
+const createAtomicLoader = require('./nunjucks/atomic-loader');
 
 var controlSHA = null;
 var lastAttemptSHA = null;

--- a/src/services/nunjucks/atomic-loader.js
+++ b/src/services/nunjucks/atomic-loader.js
@@ -1,10 +1,12 @@
-var path = require('path');
-var fs = require('fs');
-var walk = require('walk');
+'use strict';
 
-var logger = require('../../server/logging').logger;
+const path = require('path');
+const fs = require('fs');
+const walk = require('walk');
 
-var AtomicLoader = function (basePath, templateFiles) {
+const logger = require('../../server/logging').logger;
+
+const AtomicLoader = function (basePath, templateFiles) {
   this.templateSources = {};
 
   var templatePaths = Object.keys(templateFiles);
@@ -35,7 +37,7 @@ AtomicLoader.prototype.getSource = function (name) {
   return this.templateSources[name] || null;
 };
 
-var createAtomicLoader = function (rootPath, callback) {
+const createAtomicLoader = function (rootPath, callback) {
   if (!/\/$/.test(rootPath)) {
     rootPath += '/';
   }

--- a/src/services/nunjucks/index.js
+++ b/src/services/nunjucks/index.js
@@ -22,7 +22,7 @@ var NunjucksService = {
       if (err) return callback(err);
 
       staticLoader = loader;
-      staticEnv = createEnvironment(null, [staticLoader]);
+      staticEnv = createEnvironment(null, [Object.create(staticLoader)]);
       callback(null);
     });
   },
@@ -56,7 +56,7 @@ var NunjucksService = {
 module.exports = NunjucksService;
 
 var createEnvironment = function (domain, loaders) {
-  loaders.push(staticLoader);
+  loaders.push(Object.create(staticLoader));
   var env = new nunjucks.Environment(loaders, {
     autoescape: false
   });


### PR DESCRIPTION
It turns out that, regardless of the order of the Loaders used to initialize a Nunjucks environment, [if _any_ Loader in the chain has cached a specific template it will be used](https://github.com/mozilla/nunjucks/blob/v2.1.0/src/environment.js#L173-L189), even if a higher-precedence Loader has a template with the same name available but uncached.

This causes problems if a Loader is reused among multiple Environments, like the presenter's `staticLoader` that serves the fallback 404 and 500 pages. If any Environment renders the system-level 404 template, any other Environment will use the cached 404 template from the static loader without even checking for one in the control repository.

My next stab at #109.
