### PR TITLE
Configurable API segment for API endpoints

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -51,6 +51,12 @@ var configuration = {
     description: 'Override the domain of presented URLs',
     required: false
   },
+  presenter_api_path: {
+    env: 'PRESENTER_API_PATH',
+    description: 'Root path segment for API operations',
+    def: '_api',
+    required: false
+  },
   public_url_proto: {
     env: 'PUBLIC_URL_PROTO',
     description: 'Override the protocol of outgoing URLs',

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -13,9 +13,11 @@ exports.install = function (app) {
     app.get('/crash', crash);
   }
 
+  const apiPath = config.presenter_api_path();
+
   app.get('/version', version);
-  app.get('/_api/whereis/:id', api.whereis);
-  app.get('/_api/search', api.search);
+  app.get(`/${apiPath}/whereis/:id`, api.whereis);
+  app.get(`/${apiPath}/search`, api.search);
   app.get('/robots.txt', robots);
   app.get('/*', content);
 };

--- a/test/api-mapping.js
+++ b/test/api-mapping.js
@@ -10,7 +10,7 @@ const request = require('supertest');
 const server = require('../src/server');
 const ControlService = require('../src/services/control');
 
-describe('the mapping API', () => {
+describe('/_api/whereis', () => {
   beforeEach(before.reconfigure);
   beforeEach((done) => {
     ControlService.load((ok) => {
@@ -19,61 +19,59 @@ describe('the mapping API', () => {
     });
   });
 
-  describe('/_api/whereis', () => {
-    it('returns the domain and paths of a content ID', (done) => {
-      request(server.create())
-        .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fdeconst%2Fsubrepo%2Fsomepath')
-        .set('Accept', 'application/json')
-        .expect(200)
-        .expect({
-          mappings: [
-            {
-              domain: 'deconst.horse',
-              path: '/subrepo/somepath/',
-              baseContentID: 'https://github.com/deconst/subrepo/',
-              basePath: '/subrepo/'
-            }
-          ]
-        }, done);
-    });
+  it('returns the domain and paths of a content ID', (done) => {
+    request(server.create())
+      .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fdeconst%2Fsubrepo%2Fsomepath')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .expect({
+        mappings: [
+          {
+            domain: 'deconst.horse',
+            path: '/subrepo/somepath/',
+            baseContentID: 'https://github.com/deconst/subrepo/',
+            basePath: '/subrepo/'
+          }
+        ]
+      }, done);
+  });
 
-    it('returns multiple results for redundantly mapped content', (done) => {
-      request(server.create())
-        .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fdeconst%2Fredundant')
-        .set('Accept', 'application/json')
-        .expect(200)
-        .expect({
-          mappings: [
-            {
-              domain: 'deconst.horse',
-              path: '/redundant/',
-              baseContentID: 'https://github.com/deconst/redundant/',
-              basePath: '/redundant/'
-            },
-            {
-              domain: 'deconst.horse',
-              path: '/multimapped/',
-              baseContentID: 'https://github.com/deconst/redundant/',
-              basePath: '/multimapped/'
-            },
-            {
-              domain: 'deconst.dog',
-              path: '/elsewhere/',
-              baseContentID: 'https://github.com/deconst/redundant/',
-              basePath: '/elsewhere/'
-            }
-          ]
-        }, done);
-    });
+  it('returns multiple results for redundantly mapped content', (done) => {
+    request(server.create())
+      .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fdeconst%2Fredundant')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .expect({
+        mappings: [
+          {
+            domain: 'deconst.horse',
+            path: '/redundant/',
+            baseContentID: 'https://github.com/deconst/redundant/',
+            basePath: '/redundant/'
+          },
+          {
+            domain: 'deconst.horse',
+            path: '/multimapped/',
+            baseContentID: 'https://github.com/deconst/redundant/',
+            basePath: '/multimapped/'
+          },
+          {
+            domain: 'deconst.dog',
+            path: '/elsewhere/',
+            baseContentID: 'https://github.com/deconst/redundant/',
+            basePath: '/elsewhere/'
+          }
+        ]
+      }, done);
+  });
 
-    it('returns an empty collection for unknown content IDs', (done) => {
-      request(server.create())
-        .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fnope%2Fnope')
-        .set('Accept', 'application/json')
-        .expect(200)
-        .expect({
-          mappings: []
-        }, done);
-    });
+  it('returns an empty collection for unknown content IDs', (done) => {
+    request(server.create())
+      .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fnope%2Fnope')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .expect({
+        mappings: []
+      }, done);
   });
 });

--- a/test/api-mapping.js
+++ b/test/api-mapping.js
@@ -74,4 +74,23 @@ describe('/_api/whereis', () => {
         mappings: []
       }, done);
   });
+
+  it('has a different URL segment based on the configuration', (done) => {
+    before.reconfigureWith({ PRESENTER_API_PATH: 'different' })();
+
+    request(server.create())
+      .get('/different/whereis/https%3A%2F%2Fgithub.com%2Fdeconst%2Fsubrepo%2Fsomepath')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .expect({
+        mappings: [
+          {
+            domain: 'deconst.horse',
+            path: '/subrepo/somepath/',
+            baseContentID: 'https://github.com/deconst/subrepo/',
+            basePath: '/subrepo/'
+          }
+        ]
+      }, done);
+  });
 });

--- a/test/api-search.js
+++ b/test/api-search.js
@@ -61,4 +61,36 @@ describe('/_api/search', function () {
         ]
       }, done);
   });
+
+  it('has a different URL segment based on the configuration', (done) => {
+    before.reconfigureWith({ PRESENTER_API_PATH: 'different' })();
+
+    nock('http://content')
+      .get('/search?q=is')
+      .reply(200, {
+        total: 1,
+        results: [
+          {
+            contentID: 'https://github.com/deconst/fake/one',
+            title: 'first',
+            excerpt: 'this <em>is</em> result one'
+          }
+        ]
+      });
+
+    request(server.create())
+      .get('/different/search?q=is')
+      .expect(200)
+      .expect({
+        pages: 1,
+        results: [
+          {
+            contentID: 'https://github.com/deconst/fake/one',
+            url: 'https://deconst.horse/one/',
+            title: 'first',
+            excerpt: 'this <em>is</em> result one'
+          }
+        ]
+      }, done);
+  });
 });

--- a/test/api-search.js
+++ b/test/api-search.js
@@ -82,6 +82,7 @@ describe('/_api/search', function () {
       .get('/different/search?q=is')
       .expect(200)
       .expect({
+        total: 1,
         pages: 1,
         results: [
           {

--- a/test/config.js
+++ b/test/config.js
@@ -13,6 +13,7 @@ describe('config', () => {
       CONTENT_SERVICE_URL: 'https://content',
       PRESENTED_URL_PROTO: 'http',
       PRESENTED_URL_DOMAIN: 'deconst.horse',
+      PRESENTER_API_PATH: 'something',
       PUBLIC_URL_PROTO: 'https',
       PUBLIC_URL_DOMAIN: 'localhost',
       PRESENTER_LOG_LEVEL: 'debug',
@@ -22,6 +23,7 @@ describe('config', () => {
     expect(config.content_service_url()).to.equal('https://content');
     expect(config.presented_url_proto()).to.equal('http');
     expect(config.presented_url_domain()).to.equal('deconst.horse');
+    expect(config.presenter_api_path()).to.equal('something');
     expect(config.public_url_proto()).to.equal('https');
     expect(config.public_url_domain()).to.equal('localhost');
     expect(config.log_level()).to.equal('debug');

--- a/test/helpers/before.js
+++ b/test/helpers/before.js
@@ -9,6 +9,7 @@ const settings = {
   CONTENT_SERVICE_URL: 'http://content',
   PRESENTED_URL_PROTO: 'https',
   PRESENTED_URL_DOMAIN: 'deconst.horse',
+  PRESENTER_API_PATH: '_api',
   PRESENTER_LOG_LEVEL: process.env.PRESENTER_LOG_LEVEL || 'error',
   PRESENTER_LOG_COLOR: process.env.PRESENTER_LOG_COLOR
 };


### PR DESCRIPTION
Configure the parent API segment used for API endpoints from `PRESENTER_API_PATH`.

Fixes #114.
