### PR TITLE
Expose staging mode to the template context

### DIFF
--- a/src/services/template/index.js
+++ b/src/services/template/index.js
@@ -5,6 +5,7 @@ const path = require('path');
 const NunjucksService = require('../nunjucks');
 const PathService = require('../path');
 const UrlService = require('../url');
+const config = require('../../config');
 
 var TemplateService = {
   render: function (context, options, callback) {
@@ -40,7 +41,8 @@ var buildTemplateLocals = function (context, content, assets) {
       url: UrlService,
       context: context,
       request: context.request,
-      response: context.response
+      response: context.response,
+      isStaging: config.staging_mode()
     }
   };
 };

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -251,4 +251,20 @@ describe('page assembly', function () {
       .expect(200)
       .expect(/not hardcoded/, done);
   });
+
+  it('exposes staging mode to templates', (done) => {
+    nock('http://content')
+      .get('/control').reply(200, { sha: null })
+      .get('/assets').reply(200, {})
+      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fam-i-staging')
+      .reply(200, {
+        assets: [],
+        envelope: { body: 'the page content' }
+      });
+
+    request(server.create())
+      .get('/am-i-staging/')
+      .expect(200)
+      .expect(/not on staging/, done);
+  });
 });

--- a/test/staging.js
+++ b/test/staging.js
@@ -58,6 +58,23 @@ describe('staging mode', () => {
       .expect(/deconst dog content/, done);
   });
 
+  it('exposes staging mode to templates', (done) => {
+    nock('http://content')
+      .get('/control')
+      .reply(200, { sha: null })
+      .get('/assets')
+      .reply(200, {})
+      .get('/content/https%3A%2F%2Fgithub.com%2Fbuild-12345%2Fdeconst%2Ffake%2Fam-i-staging')
+      .reply(200, {
+        envelope: { body: 'subpath content' }
+      });
+
+    request(server.create())
+      .get('/build-12345/am-i-staging/')
+      .expect(200)
+      .expect(/this is staging/, done);
+  });
+
   describe('link manipulation', () => {
     it('prepends revision ID to root-relative links', (done) => {
       nock('http://content')

--- a/test/test-control/config/routes.json
+++ b/test/test-control/config/routes.json
@@ -5,7 +5,8 @@
             "^/search/?$": "search.html",
             "^/searchparams/?$": "searchparams.html",
             "^/searchcats/?$": "searchcats.html",
-            "^/with-template-link/?$": "link.html"
+            "^/with-template-link/?$": "link.html",
+            "^/am-i-staging/$": "isstaging.html"
         }
     },
     "deconst.dog": {

--- a/test/test-control/templates/deconst.horse/isstaging.html
+++ b/test/test-control/templates/deconst.horse/isstaging.html
@@ -1,0 +1,9 @@
+<h1><code>isstaging.html</code></h1>
+
+{% if deconst.isStaging %}
+<h2>this is staging</h2>
+{% else %}
+<h2>not on staging</h2>
+{% endif %}
+
+{{ deconst.content.envelope.body }}


### PR DESCRIPTION
Add a `deconst.isStaging` property to the Nunjucks template context to allow templates to visually distinguish between content served on the staging server and content served on production.

Fixes #117.
