### PR TITLE
adjust the relative URL regex to also catch absolute URLs

### DIFF
--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -165,11 +165,11 @@ module.exports = function (req, res) {
           return callback(null, null);
         }
 
-        var relativeUrls = /href=("|')(..\/)?([^\/].*?)("|')/g;
+        var relativeUrls = /href=("|')(?![a-z]+:\/?\/?|\/)(?:\.\.\/)?(.+?)("|')/g;
         toc.envelope.body =
           toc.envelope.body.replace(
             relativeUrls,
-            'href=$1' + prefix + '$3$4'
+            'href=$1' + prefix + '$2$3'
         );
 
         return callback(null, toc.envelope.body);


### PR DESCRIPTION
This is to support a not-so-great fix to https://github.com/rackerlabs/docs-core-infra-user-guide/issues/408. As a stopgap to the _actually_ improved TOC handling, an absolute URL to where a document lives on DRC is a simple way to get that issue closed.

Prior to this, an absolute URL was caught as a relative URL and the presenter tried to add a path prefix to it.

/cc @smashwilson 
