### PR TITLE
Filter {{ to() }} directives within TOC envelopes

### DIFF
--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -25,13 +25,11 @@ ContentFilterService.add(function (input, next) {
   // until presenter-time.
   let urlDirectiveRx = /\{\{\s*to\('([^']+)'\)\s*\}\}/g;
 
-  if (content.contentID && content.envelope) {
+  if (content.envelope) {
     // Replace any "{{ to() }}" directives with the appropriate presented URL.
     content.envelope.body = content.envelope.body.replace(
       urlDirectiveRx,
-      function (match, contentID) {
-        return ContentRoutingService.getPresentedUrl(context, contentID);
-      }
+      (match, contentID) => ContentRoutingService.getPresentedUrl(context, contentID)
     );
   }
 

--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -23,14 +23,22 @@ ContentFilterService.add(function (input, next) {
 
   // Match nunjucks-like "{{ to('') }}" directives that are used to defer rendering of presented URLs
   // until presenter-time.
-  let urlDirectiveRx = /\{\{\s*to\('([^']+)'\)\s*\}\}/g;
+  const urlDirectiveRx = /\{\{\s*to\('([^']+)'\)\s*\}\}/g;
 
-  if (content.envelope) {
-    // Replace any "{{ to() }}" directives with the appropriate presented URL.
-    content.envelope.body = content.envelope.body.replace(
+  // Replace any "{{ to() }}" directives with the appropriate presented URL.
+  const replaceToDirective = (source) => {
+    return source.replace(
       urlDirectiveRx,
       (match, contentID) => ContentRoutingService.getPresentedUrl(context, contentID)
     );
+  };
+
+  if (content.envelope && content.envelope.body) {
+    content.envelope.body = replaceToDirective(content.envelope.body);
+  }
+
+  if (content.globals && content.globals.toc) {
+    content.globals.toc = replaceToDirective(content.globals.toc);
   }
 
   return next();

--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -171,7 +171,7 @@ module.exports = function (req, res) {
           return callback(null, null);
         }
 
-        var relativeUrls = /href=("|')(?![a-z]+:\/?\/?|\/)(?:\.\.\/)?(.+?)("|')/g;
+        var relativeUrls = /href=("|')(?![a-z]+:\/?\/?|\/|\{\{)(?:\.\.\/)?(.+?)("|')/g;
         toc.envelope.body =
           toc.envelope.body.replace(
             relativeUrls,

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -267,4 +267,20 @@ describe('page assembly', function () {
       .expect(200)
       .expect(/not on staging/, done);
   });
+
+  it('substitutes {{ to() }} directives', (done) => {
+    nock('http://content')
+      .get('/control').reply(200, { sha: null })
+      .get('/assets').reply(200, {})
+      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
+      .reply(200, {
+        assets: [],
+        envelope: { body: "with a {{ to('https://github.com/deconst/subrepo/some/page') }} reference" }
+      });
+
+    request(server.create())
+      .get('/')
+      .expect(200)
+      .expect(/with a https:\/\/deconst\.horse\/subrepo\/some\/page\/ reference/, done);
+  });
 });


### PR DESCRIPTION
When fetching the TOC, substitute any `{{ to('content-id') }}` directives with their corresponding presented URLs.

This is an incremental step toward the improved TOC handling from deconst/preparer-sphinx#51 that'll let me ship deconst/preparer-sphinx#64 without breaking all of the TOCs on the existing site.
