### PR TITLE
Support envelope addenda

### DIFF
--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -261,8 +261,6 @@ module.exports = function (req, res) {
       assets
     };
 
-    logger.debug('Template options', options);
-
     TemplateService.render(context, options, (err, result) => {
       if (err) return cb(err);
 

--- a/src/services/template/index.js
+++ b/src/services/template/index.js
@@ -10,7 +10,7 @@ const config = require('../../config');
 var TemplateService = {
   render: function (context, options, callback) {
     var templateFile = findTemplate(context, options.templatePath);
-    var templateLocals = buildTemplateLocals(context, options.content, options.assets);
+    var templateLocals = buildTemplateLocals(context, options);
     var startTs = Date.now();
 
     NunjucksService.getEnvironment(context, function (err, env) {
@@ -27,17 +27,23 @@ var TemplateService = {
 
 module.exports = TemplateService;
 
-var buildTemplateLocals = function (context, content, assets) {
-  if (assets) {
+var buildTemplateLocals = function (context, options) {
+  if (options.assets) {
     // Some templates still use deconst.content.assets instead of deconst.assets
-    content.assets = assets;
+    options.content.assets = options.assets;
+  }
+
+  // TOC compatibility
+  if (options.addenda && options.addenda.repository_toc) {
+    options.content.globals.toc = options.addenda.repository_toc.envelope.body;
   }
 
   return {
     deconst: {
       env: process.env,
-      content: content || {},
-      assets: assets || {},
+      content: options.content || {},
+      assets: options.assets || {},
+      addenda: options.addenda || {},
       url: UrlService,
       context: context,
       request: context.request,

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -283,4 +283,29 @@ describe('page assembly', function () {
       .expect(200)
       .expect(/with a https:\/\/deconst\.horse\/subrepo\/some\/page\/ reference/, done);
   });
+
+  it('fetches envelope addenda', (done) => {
+    nock('http://content')
+      .get('/control').reply(200, { sha: null })
+      .get('/assets').reply(200, {})
+      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Foriginal')
+      .reply(200, {
+        envelope: {
+          addenda: { some_name: 'https://github.com/deconst/fake/_other' },
+          body: 'original'
+        }
+      })
+      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2F_other')
+      .reply(200, {
+        envelope: {
+          body: 'other'
+        }
+      });
+
+    request(server.create())
+      .get('/original/')
+      .expect(200)
+      .expect(/addenda: "other"/)
+      .expect(/body: "original"/, done);
+  });
 });

--- a/test/test-control/config/routes.json
+++ b/test/test-control/config/routes.json
@@ -6,7 +6,8 @@
             "^/searchparams/?$": "searchparams.html",
             "^/searchcats/?$": "searchcats.html",
             "^/with-template-link/?$": "link.html",
-            "^/am-i-staging/$": "isstaging.html"
+            "^/am-i-staging/$": "isstaging.html",
+            "^/original/$": "addenda.html"
         }
     },
     "deconst.dog": {

--- a/test/test-control/templates/deconst.horse/addenda.html
+++ b/test/test-control/templates/deconst.horse/addenda.html
@@ -1,4 +1,4 @@
 <h1><code>addenda.html</code></h1>
 
-addenda: "{{ deconst.addenda.some_name.body }}"
+addenda: "{{ deconst.addenda.some_name.envelope.body }}"
 body: "{{ deconst.content.envelope.body }}"

--- a/test/test-control/templates/deconst.horse/addenda.html
+++ b/test/test-control/templates/deconst.horse/addenda.html
@@ -1,0 +1,4 @@
+<h1><code>addenda.html</code></h1>
+
+addenda: "{{ deconst.addenda.some_name.body }}"
+body: "{{ deconst.content.envelope.body }}"


### PR DESCRIPTION
Remove the special-cased `_toc` envelope fetch. Instead, if an envelope contains an `addenda` element, fetch each referenced envelope and make it available to the template context.

Fixes #120.
