### PR TITLE
Force control repository updates

### DIFF
--- a/src/services/control.js
+++ b/src/services/control.js
@@ -344,7 +344,16 @@ const gitClone = function (url, branch, repoPath, callback) {
 };
 
 const gitPull = function (repoPath, callback) {
-  git(['pull'], repoPath, (err) => {
+  // Destroy any local modifications and forcibly set the workspace and index to the most
+  // recently fetched branch tip.
+
+  const fetch = (cb) => git(['fetch', '--force'], repoPath, cb);
+
+  const clean = (cb) => git(['clean', '--force', '-d'], repoPath, cb);
+
+  const reset = (cb) => git(['reset', '--hard', 'FETCH_HEAD'], repoPath, cb);
+
+  async.series([fetch, clean, reset], (err) => {
     if (err) return callback(err);
 
     readCurrentSHA(repoPath, callback);

--- a/src/services/control.js
+++ b/src/services/control.js
@@ -17,19 +17,21 @@ const RewriteService = require('./rewrite');
 const NunjucksService = require('./nunjucks');
 const createAtomicLoader = require('./nunjucks/atomic-loader');
 
-var controlSHA = null;
-var lastAttemptSHA = null;
-var updateInProgress = false;
-var cachePath = null;
+let controlSHA = null;
+let lastAttemptSHA = null;
+let updateInProgress = false;
+let cachePath = null;
 
-var ControlService = {
-  load: function (callback) {
-    var startTs = Date.now();
-    logger.info('Loading control repository');
+const ControlService = {
+  load: function (sha, callback) {
+    const startTs = Date.now();
+    logger.info('Loading control repository', { service: 'control', sha });
 
-    NunjucksService.initialize(function (err) {
+    NunjucksService.initialize((err) => {
       if (err) {
         logger.error('Unable to bootstrap nunjucks templates.', {
+          service: 'control',
+          sha,
           errMessage: err.message,
           stack: err.stack,
           duration: Date.now() - startTs
@@ -44,9 +46,11 @@ var ControlService = {
         rewriteMap: readRewriteMap,
         plugins: loadPlugins,
         loaders: loadTemplates
-      }, function (err, result) {
+      }, (err, result) => {
         if (err) {
           logger.error('Unable to load control repository', {
+            service: 'control',
+            sha,
             errMessage: err.message,
             stack: err.stack,
             duration: Date.now() - startTs
@@ -59,10 +63,10 @@ var ControlService = {
         TemplateRoutingService.setTemplateMap(result.templateMap);
         RewriteService.setRewriteMap(result.rewriteMap);
 
-        var domains = [];
-        for (var domain in result.contentMap) {
-          var plugins = result.plugins[domain] || [];
-          var loaders = [];
+        const domains = [];
+        for (let domain in result.contentMap) {
+          const plugins = result.plugins[domain] || [];
+          const loaders = [];
           if (result.loaders[domain]) {
             loaders.push(result.loaders[domain]);
           }
@@ -73,7 +77,9 @@ var ControlService = {
         }
 
         logger.info('Successfully loaded control repository', {
-          domains: domains,
+          service: 'control',
+          sha,
+          domains,
           duration: Date.now() - startTs
         });
 
@@ -84,102 +90,101 @@ var ControlService = {
   update: function (sha, callback) {
     // The callback is optional.
     if (!callback) {
-      callback = function () {};
+      callback = () => {};
     }
 
     if (updateInProgress) {
       return callback(false);
     }
 
-    var startTs = Date.now();
-    logger.info('Updating control repository', {
-      sha: sha
-    });
-
+    const startTs = Date.now();
     if (sha !== null && lastAttemptSHA === sha) {
-      logger.info('Skipping load of already-attempted SHA', {
-        sha: sha,
-        lastAttemptSHA: lastAttemptSHA
-      });
+      logger.info('Skipping load of already-attempted SHA', { service: 'control', sha });
       return callback(false);
     }
     lastAttemptSHA = sha;
 
-    var isGit = !!config.control_repo_url();
-    var shouldUpdate = (sha === null) || (sha !== controlSHA);
+    const isGit = !!config.control_repo_url();
+    const shouldUpdate = (sha === null) || (sha !== controlSHA);
 
     if (!shouldUpdate) {
-      logger.info('Control repository SHA is already up to date.', {
-        sha: sha
-      });
+      logger.info('Control repository is already up to date.', { service: 'control', sha });
 
       return callback(false);
     }
 
+    logger.info('Updating control repository', { service: 'control', sha });
     updateInProgress = true;
 
-    var handleErr = function (err) {
+    const handleErr = (err) => {
       logger.error('Unable to update control repository', {
+        service: 'control',
+        sha,
         errMessage: err.message,
-        stack: err.stack,
-        sha: sha
+        stack: err.stack
       });
 
       updateInProgress = false;
       callback(false);
     };
 
-    var gitStartTs = null;
-    var gitCompletePayload = null;
+    let gitStartTs = null;
+    let gitCompletePayload = null;
 
-    var andLoad = function (err, newSHA) {
+    const andLoad = (err, newSHA) => {
       if (err) return handleErr(err);
 
       if (gitStartTs !== null && gitCompletePayload !== null) {
         gitCompletePayload.duration = Date.now() - gitStartTs;
-        var msg = gitCompletePayload.message;
+        const msg = gitCompletePayload.message;
         delete gitCompletePayload.message;
 
         logger.info(msg, gitCompletePayload);
       }
 
-      this.load(function (ok) {
+      this.load(newSHA, (ok) => {
         if (ok) {
           logger.info('Control repository update complete.', {
+            service: 'control',
             fromSHA: controlSHA,
-            toSHA: newSHA,
+            sha: newSHA,
             duration: Date.now() - startTs
           });
 
           controlSHA = newSHA;
         } else {
           logger.error('Control repository load failed.', {
+            service: 'control',
             currentSHA: controlSHA,
-            toSHA: sha
+            sha: newSHA
           });
         }
 
         updateInProgress = false;
         callback(ok);
       });
-    }.bind(this);
+    };
 
     if (isGit) {
-      var parentPath = path.dirname(PathService.getControlRepoPath());
+      const parentPath = path.dirname(PathService.getControlRepoPath());
 
-      mkdirp(parentPath, function (err) {
+      mkdirp(parentPath, (err) => {
         if (err) return handleErr(err);
 
-        fs.readdir(PathService.getControlRepoPath(), function (err, contents) {
+        fs.readdir(PathService.getControlRepoPath(), (err, contents) => {
           if (err) {
             if (err.code === 'ENOENT') {
               // New repository.
 
               logger.debug('Beginning control repository clone', {
+                service: 'control',
+                sha,
                 url: config.control_repo_url(),
                 branch: config.control_repo_branch()
               });
               gitCompletePayload = {
+                service: 'control',
+                sha,
                 message: 'Completed control repository clone',
                 url: config.control_repo_url(),
                 branch: config.control_repo_branch()
@@ -198,7 +203,7 @@ var ControlService = {
           }
 
           // Existing repository.
-          logger.debug('Beginning control repository pull');
+          logger.debug('Beginning control repository pull', { service: 'control', sha });
           gitCompletePayload = {message: 'Completed control repository pull'};
           gitStartTs = Date.now();
 
@@ -209,7 +214,7 @@ var ControlService = {
       });
     } else {
       // Non-git repository. Most likely a local mount.
-      logger.debug('Skipping update for non-git control repository.');
+      logger.debug('Skipping update for non-git control repository.', { service: 'control', sha });
 
       return andLoad(null, 'non-git');
     }
@@ -221,7 +226,7 @@ var ControlService = {
 
 module.exports = ControlService;
 
-var readAndMergeConfigFiles = function (files, def, callback) {
+const readAndMergeConfigFiles = function (files, def, callback) {
   // for compatibility. Might be called with files as a single path, not an
   // array of paths
   if (!Array.isArray(files)) {
@@ -229,7 +234,7 @@ var readAndMergeConfigFiles = function (files, def, callback) {
   }
 
   async.reduce(files, {}, function (previousValue, currentValue, reduceCallback) {
-    fs.readFile(currentValue, {encoding: 'utf-8'}, function (err, body) {
+    fs.readFile(currentValue, {encoding: 'utf-8'}, (err, body) => {
       if (err) {
         if (err.code === 'ENOENT') {
           return callback(null, def);
@@ -238,12 +243,13 @@ var readAndMergeConfigFiles = function (files, def, callback) {
         return callback(err);
       }
 
-      var doc;
+      let doc;
       try {
         doc = JSON.parse(body);
       } catch (e) {
         doc = {};
         logger.warn('Configuration file contained invalid JSON', {
+          service: 'control',
           errMessage: e.message,
           filename: currentValue,
           source: body
@@ -253,7 +259,7 @@ var readAndMergeConfigFiles = function (files, def, callback) {
       // I'm surprised this little concatenation loop works as well as it does.
       // Could definitely use some testing to be sure it covers all the
       // _reasonable_ use cases.
-      for (var site in doc) {
+      for (let site in doc) {
         if (doc.hasOwnProperty(site)) {
           if (previousValue.hasOwnProperty(site)) {
             previousValue[site] = previousValue[site].concat(doc[site]);
@@ -268,12 +274,12 @@ var readAndMergeConfigFiles = function (files, def, callback) {
   }, callback);
 };
 
-var subdirectories = function (rootPath, callback) {
-  fs.readdir(rootPath, function (err, entries) {
+const subdirectories = function (rootPath, callback) {
+  fs.readdir(rootPath, (err, entries) => {
     if (err) return callback(err);
 
-    async.filter(entries, function (entry, cb) {
-      fs.stat(path.join(rootPath, entry), function (err, fstat) {
+    async.filter(entries, (entry, cb) => {
+      fs.stat(path.join(rootPath, entry), (err, fstat) => {
         if (err) return callback(err, null);
         cb(null, fstat.isDirectory());
       });
@@ -281,95 +287,123 @@ var subdirectories = function (rootPath, callback) {
   });
 };
 
-var readCurrentSHA = function (repoPath, callback) {
-  return function (err, stdout, stderr) {
-    if (err) {
-      err.stdout = stdout;
-      err.stderr = stderr;
-      return callback(err);
+const git = function (args, cwd, callback) {
+  const options = {};
+  if (cwd) options.cwd = cwd;
+  const stdoutChunks = [];
+  const stderrChunks = [];
+
+  const stdout = () => Buffer.concat(stdoutChunks).toString('utf-8');
+  const stderr = () => Buffer.concat(stderrChunks).toString('utf-8');
+
+  const p = childProcess.spawn('/usr/bin/git', args, options);
+
+  p.stdout.on('data', (chunk) => stdoutChunks.push(chunk));
+
+  p.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+
+  p.on('close', (status) => {
+    if (status !== 0) {
+      const e = new Error(`git command ${args} exited with non-zero status ${status}`);
+      e.gitArgs = args;
+      e.status = status;
+      e.stdout = stdout();
+      e.stderr = stderr();
+      return callback(e);
     }
 
-    childProcess.execFile(
-      '/usr/bin/git',
-      ['rev-parse', 'HEAD'],
-      {cwd: repoPath},
-      function (err, stdout, stderr) {
-        if (err) {
-          err.stdout = stdout;
-          err.stderr = stderr;
-          return callback(err);
-        }
+    callback(null, {
+      stdout: stdout(),
+      stderr: stderr()
+    });
+  });
 
-        callback(null, stdout.replace(/\r?\n$/, ''));
-      }
-    );
-  };
+  p.on('error', (err) => {
+    err.gitArgs = args;
+    err.stdout = stdout();
+    err.stderr = stderr();
+
+    return callback(err);
+  });
 };
 
-var gitClone = function (url, branch, repoPath, callback) {
-  childProcess.execFile(
-    '/usr/bin/git',
-    ['clone', '--branch', branch, url, repoPath],
-    readCurrentSHA(repoPath, callback)
-  );
+const readCurrentSHA = function (repoPath, callback) {
+  git(['rev-parse', 'HEAD'], repoPath, (err, output) => {
+    if (err) return callback(err);
+
+    callback(null, output.stdout.replace(/\r?\n$/, ''));
+  });
 };
 
-var gitPull = function (repoPath, callback) {
-  childProcess.execFile(
-    '/usr/bin/git',
-    ['pull'],
-    {cwd: repoPath},
-    readCurrentSHA(repoPath, callback)
-  );
+const gitClone = function (url, branch, repoPath, callback) {
+  git(['clone', '--branch', branch, url, repoPath], null, (err) => {
+    if (err) return callback(err);
+
+    readCurrentSHA(repoPath, callback);
+  });
+};
+
+const gitPull = function (repoPath, callback) {
+  git(['pull'], repoPath, (err) => {
+    if (err) return callback(err);
+
+    readCurrentSHA(repoPath, callback);
+  });
 };
 
 // Read functions
 
-var readContentMap = function (callback) {
-  var contentFiles = PathService.getContentFiles();
+const readContentMap = function (callback) {
+  const contentFiles = PathService.getContentFiles();
 
   logger.debug('Beginning content map load', {
+    service: 'control',
     files: contentFiles
   });
 
-  readAndMergeConfigFiles(contentFiles, {}, function (err, contentMap) {
+  readAndMergeConfigFiles(contentFiles, {}, (err, contentMap) => {
     if (err) return callback(err);
 
     logger.debug('Successfully loaded content map', {
+      service: 'control',
       files: contentFiles
     });
     callback(null, contentMap);
   });
 };
 
-var readTemplateMap = function (callback) {
+const readTemplateMap = function (callback) {
   var routeFiles = PathService.getRoutesFiles();
 
   logger.debug('Begining template map load', {
+    service: 'control',
     files: routeFiles
   });
 
-  readAndMergeConfigFiles(routeFiles, {}, function (err, templateMap) {
+  readAndMergeConfigFiles(routeFiles, {}, (err, templateMap) => {
     if (err) return callback(err);
 
     logger.debug('Successfully loaded template map', {
+      service: 'control',
       filename: routeFiles
     });
     callback(null, templateMap);
   });
 };
 
-var readRewriteMap = function (callback) {
-  var rewriteFiles = PathService.getRewritesFiles();
+const readRewriteMap = function (callback) {
+  const rewriteFiles = PathService.getRewritesFiles();
 
   logger.debug('Beginning rewrite map load', {
+    service: 'control',
     files: rewriteFiles
   });
 
-  readAndMergeConfigFiles(rewriteFiles, {}, function (err, rewriteMap) {
+  readAndMergeConfigFiles(rewriteFiles, {}, (err, rewriteMap) => {
     if (err) return callback(err);
 
     logger.debug('Successfully loaded rewrite map', {
+      service: 'control',
       files: rewriteFiles
     });
 
@@ -377,14 +411,15 @@ var readRewriteMap = function (callback) {
   });
 };
 
-var loadPlugins = function (callback) {
-  var pluginsRoot = PathService.getPluginsRoot();
-  var beginTs = Date.now();
+const loadPlugins = function (callback) {
+  const pluginsRoot = PathService.getPluginsRoot();
+  const beginTs = Date.now();
   logger.debug('Beginning plugin load', {
+    service: 'control',
     path: pluginsRoot
   });
 
-  subdirectories(pluginsRoot, function (err, subdirs) {
+  subdirectories(pluginsRoot, (err, subdirs) => {
     if (err) {
       if (err.code === 'ENOENT') {
         // No plugins to enumerate.
@@ -394,17 +429,18 @@ var loadPlugins = function (callback) {
       return callback(err);
     }
 
-    async.map(subdirs, loadDomainPlugins, function (err, results) {
+    async.map(subdirs, loadDomainPlugins, (err, results) => {
       if (err) return callback(err);
 
       logger.debug('Successfully loaded plugins', {
+        service: 'control',
         path: pluginsRoot,
         pluginCount: results.length,
         duration: Date.now() - beginTs
       });
 
-      var output = {};
-      for (var i = 0; i < results.length; i++) {
+      const output = {};
+      for (let i = 0; i < results.length; i++) {
         output[subdirs[i]] = results[i];
       }
 
@@ -413,47 +449,44 @@ var loadPlugins = function (callback) {
   });
 };
 
-var loadDomainPlugins = function (domain, callback) {
-  var domainRoot = path.join(PathService.getPluginsRoot(), domain);
+const loadDomainPlugins = function (domain, callback) {
+  const domainRoot = path.join(PathService.getPluginsRoot(), domain);
 
-  subdirectories(domainRoot, function (err, subdirs) {
+  subdirectories(domainRoot, (err, subdirs) => {
     if (err) return callback(err);
 
-    async.map(subdirs, function (subdir, cb) {
+    async.map(subdirs, (subdir, cb) => {
       loadDomainPlugin(path.join(domainRoot, subdir), cb);
-    }, function (err, results) {
-      if (err) return callback(err);
-
-      callback(null, results);
-    });
+    }, callback);
   });
 };
 
-var loadDomainPlugin = function (pluginRoot, callback) {
-  var startTs = Date.now();
+const loadDomainPlugin = function (pluginRoot, callback) {
+  const startTs = Date.now();
   logger.debug('Loading plugin', {
+    service: 'control',
     pluginRoot: pluginRoot
   });
 
-  var deps = null;
-  var plugin = null;
+  let deps = null;
+  let plugin = null;
 
-  var createDir = function (cb) {
+  const createDir = (cb) => {
     if (cachePath !== null) {
       return cb(null);
     }
 
-    tmp.dir({prefix: 'npm-cache-'}, function (err, cp) {
+    tmp.dir({prefix: 'npm-cache-'}, (err, cp) => {
       cachePath = cp;
       cb(err);
     });
   };
 
-  var parseDependencies = function (cb) {
-    fs.readFile(path.join(pluginRoot, 'package.json'), {encoding: 'utf-8'}, function (err, doc) {
+  const parseDependencies = (cb) => {
+    fs.readFile(path.join(pluginRoot, 'package.json'), {encoding: 'utf-8'}, (err, doc) => {
       if (err) return cb(err);
 
-      var depDoc = {};
+      let depDoc = {};
       try {
         depDoc = JSON.parse(doc);
       } catch (e) {
@@ -461,7 +494,7 @@ var loadDomainPlugin = function (pluginRoot, callback) {
       }
 
       deps = [];
-      for (var key in depDoc.dependencies) {
+      for (let key in depDoc.dependencies) {
         deps.push(key + '@' + depDoc.dependencies[key]);
       }
 
@@ -469,19 +502,20 @@ var loadDomainPlugin = function (pluginRoot, callback) {
     });
   };
 
-  var installDependencies = function (cb) {
-    npm.load({cache: cachePath}, function (err) {
+  const installDependencies = (cb) => {
+    npm.load({cache: cachePath}, (err) => {
       if (err) return cb(err);
 
-      npm.commands.install(pluginRoot, deps, function (err, result) {
+      npm.commands.install(pluginRoot, deps, (err, result) => {
         if (err) return cb(err);
 
         logger.debug('Plugin dependencies installed', {
+          service: 'control',
           pluginRoot: pluginRoot,
           duration: Date.now() - startTs
         });
 
-        var requireTs = Date.now();
+        const requireTs = Date.now();
         try {
           plugin = require(pluginRoot);
         } catch (e) {
@@ -489,6 +523,7 @@ var loadDomainPlugin = function (pluginRoot, callback) {
         }
 
         logger.debug('Plugin required', {
+          service: 'control',
           pluginRoot: pluginRoot,
           duration: Date.now() - requireTs
         });
@@ -502,23 +537,25 @@ var loadDomainPlugin = function (pluginRoot, callback) {
     createDir,
     parseDependencies,
     installDependencies
-  ], function (err) {
+  ], (err) => {
     return callback(err, plugin);
   });
 };
 
-var loadTemplates = function (callback) {
-  var startTs = Date.now();
-  var templatesRoot = PathService.getTemplatesRoot();
+const loadTemplates = function (callback) {
+  const startTs = Date.now();
+  const templatesRoot = PathService.getTemplatesRoot();
   logger.debug('Beginning template preload', {
-    templatesRoot: templatesRoot
+    service: 'control',
+    templatesRoot
   });
 
-  subdirectories(templatesRoot, function (err, subdirs) {
+  subdirectories(templatesRoot, (err, subdirs) => {
     if (err) {
       if (err.code === 'ENOENT') {
         // No templates to load in this control repository.
         logger.debug('No templates to load', {
+          service: 'control',
           duration: Date.now() - startTs
         });
 
@@ -528,19 +565,20 @@ var loadTemplates = function (callback) {
       return callback(err);
     }
 
-    async.map(subdirs, function (subdir, cb) {
+    async.map(subdirs, (subdir, cb) => {
       var fullPath = path.resolve(templatesRoot, subdir);
 
       createAtomicLoader(fullPath, cb);
-    }, function (err, results) {
+    }, (err, results) => {
       if (err) return callback(err);
 
-      var output = {};
+      const output = {};
       for (var i = 0; i < results.length; i++) {
         output[subdirs[i]] = results[i];
       }
 
       logger.debug('Successfully preloaded templates', {
+        service: 'control',
         domains: subdirs,
         duration: Date.now() - startTs
       });

--- a/test/api-mapping.js
+++ b/test/api-mapping.js
@@ -13,7 +13,7 @@ const ControlService = require('../src/services/control');
 describe('/_api/whereis', () => {
   beforeEach(before.reconfigure);
   beforeEach((done) => {
-    ControlService.load((ok) => {
+    ControlService.load('sha', (ok) => {
       if (!ok) return done(new Error('Control repository load failed'));
       done();
     });

--- a/test/api-search.js
+++ b/test/api-search.js
@@ -14,7 +14,7 @@ const ControlService = require('../src/services/control');
 describe('/_api/search', function () {
   beforeEach(before.reconfigure);
   beforeEach((done) => {
-    ControlService.load((ok) => {
+    ControlService.load('sha', (ok) => {
       if (!ok) return done(new Error('Control repository load failed'));
       done();
     });

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -19,7 +19,7 @@ describe('page assembly', function () {
   beforeEach(function (done) {
     config.configure(before.settings);
 
-    ControlService.load(function (ok) {
+    ControlService.load('sha', (ok) => {
       if (!ok) {
         return done(new Error('Control repository load failed'));
       }

--- a/test/control-repo.js
+++ b/test/control-repo.js
@@ -17,7 +17,7 @@ nock.enableNetConnect('127.0.0.1');
 var mockControl = function (mfs, callback) {
   if (mfs !== null) mockfs(mfs);
 
-  ControlService.load(function (ok) {
+  ControlService.load('sha', (ok) => {
     if (mfs !== null) mockfs.restore();
 
     if (!ok) {

--- a/test/staging.js
+++ b/test/staging.js
@@ -18,7 +18,7 @@ describe('staging mode', () => {
     STAGING_MODE: 'true'
   }));
   beforeEach((done) => {
-    ControlService.load((ok) => {
+    ControlService.load('sha', (ok) => {
       if (!ok) return done(new Error('Control repository load failed'));
       done();
     });


### PR DESCRIPTION
The control repository clone within the container is never written to, but if HEAD's upstream branch has diverged, `git pull` will fail and not be able to correct itself without a restart. Replace it with a `git fetch` followed by a `git reset --hard FETCH_HEAD` to forcibly overwrite the local ref with the fetched one.

Tag logging messages written during control repository reloads with `"service": "control"` to make them easier to filter within Kibana.

Log stdout and stderr of any git commands that exit with a non-zero status.

Fixes #124.
