### PR TITLE
Consistently map content IDs in whereis

### DIFF
--- a/src/services/content/routing.js
+++ b/src/services/content/routing.js
@@ -99,17 +99,25 @@ const ContentRoutingService = {
 
     let mappings = [];
 
+    // Normalize the contentID with a trailing slash so that the .indexOf() and .replace() checks
+    // work correctly.
+    if (!contentID.endsWith('/')) {
+      contentID = contentID + '/';
+    }
+
     domainContentMaps.forEach((domainContent) => {
       for (let basePath in domainContent.map) {
         let baseContentID = domainContent.map[basePath];
         if (baseContentID === null) continue;
 
-        // Normalize the baseContentID without a trailing slash so the .replace() works correctly.
-        baseContentID = baseContentID.replace(/\/$/, '');
+        // Normalize the baseContentID with a trailing slash as well.
+        if (!baseContentID.endsWith('/')) {
+          baseContentID = baseContentID + '/';
+        }
 
         if (contentID.indexOf(baseContentID) !== -1) {
           let domain = domainContent.domain;
-          let subPath = contentID.replace(baseContentID, '');
+          let subPath = '/' + contentID.replace(baseContentID, '');
 
           if (config.staging_mode()) {
             baseContentID = RevisionService.applyToContentID(revisionID, baseContentID);
@@ -121,7 +129,7 @@ const ContentRoutingService = {
 
           mappings.push({
             domain,
-            baseContentID: `${baseContentID}/`,
+            baseContentID,
             basePath,
             path: sitePath
           });

--- a/test/api-mapping.js
+++ b/test/api-mapping.js
@@ -65,6 +65,23 @@ describe('/_api/whereis', () => {
       }, done);
   });
 
+  it('correctly handles when one content ID base is a prefix of another', (done) => {
+    request(server.create())
+      .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fdeconst%2Fprefix-2.0')
+      .set('Accept', 'application/json')
+      .expect(200)
+      .expect({
+        mappings: [
+          {
+            domain: 'deconst.horse',
+            path: '/prefix-2.0/',
+            baseContentID: 'https://github.com/deconst/prefix-2.0/',
+            basePath: '/prefix-2.0/'
+          }
+        ]
+      }, done);
+  });
+
   it('returns an empty collection for unknown content IDs', (done) => {
     request(server.create())
       .get('/_api/whereis/https%3A%2F%2Fgithub.com%2Fnope%2Fnope')

--- a/test/test-control/config/content.json
+++ b/test/test-control/config/content.json
@@ -5,6 +5,8 @@
             "/subrepo/": "https://github.com/deconst/subrepo/",
             "/redundant/": "https://github.com/deconst/redundant/",
             "/multimapped/": "https://github.com/deconst/redundant/",
+            "/prefix/": "https://github.com/deconst/prefix/",
+            "/prefix-2.0/": "https://github.com/deconst/prefix-2.0/",
             "/search/": null,
             "/searchparams/": null,
             "/searchcats/": null


### PR DESCRIPTION
There's an extraneous result in the mapping query when one content ID base is an exact prefix of another, which causing incorrect preview links to be generated by the Strider plugin.

Fixes #127.
