### PR TITLE
Fix a bug in the template compatibility shim.

### DIFF
--- a/src/services/template/index.js
+++ b/src/services/template/index.js
@@ -35,6 +35,10 @@ var buildTemplateLocals = function (context, options) {
 
   // TOC compatibility
   if (options.addenda && options.addenda.repository_toc) {
+    if (!options.content.globals) {
+      options.content.globals = {};
+    }
+
     options.content.globals.toc = options.addenda.repository_toc.envelope.body;
   }
 


### PR DESCRIPTION
This fixes a presenter crash that occurs when the template compatibility shim that populates `content.globals` was invoked.
