### PR TITLE
Duck-type contentIDs to Strings for logging.

### DIFF
--- a/src/helpers/context.js
+++ b/src/helpers/context.js
@@ -48,7 +48,8 @@ Context.prototype._summarize = function (statusCode, message, err) {
   };
 
   if (this.contentId !== null) {
-    summary.contentID = this.contentId;
+    // Normalize sentinel "IDs" like UNMAPPED and EMPTY_ENVELOPE to Strings.
+    summary.contentID = this.contentId.toString();
   }
 
   if (this.templatePath !== null) {


### PR DESCRIPTION
Elasticsearch automatically creates type mappings for a given index and type based on the implied schema of the first document indexed within it. If either of the sentinel `ContentRoutingService` objects `UNMAPPED` or `EMPTY_ENVELOPE` were encountered first, Elasticsearch infers an "object" type and drops _all other logging messages with a contentID field_. If a string contentID is encountered first (far more common), then we were silently dropping any `UNMAPPED` or `EMPTY_ENVELOPE` messages instead. Oops.
