### PR TITLE
Remove the TOC compatibility shim

### DIFF
--- a/src/services/template/index.js
+++ b/src/services/template/index.js
@@ -33,15 +33,6 @@ var buildTemplateLocals = function (context, options) {
     options.content.assets = options.assets;
   }
 
-  // TOC compatibility
-  if (options.addenda && options.addenda.repository_toc) {
-    if (!options.content.globals) {
-      options.content.globals = {};
-    }
-
-    options.content.globals.toc = options.addenda.repository_toc.envelope.body;
-  }
-
   return {
     deconst: {
       env: process.env,


### PR DESCRIPTION
Once rackerlabs/nexus-control#453 has shipped and no other templates are using the `deconst.content.globals.toc` reference any more, remove the temporary workaround.
