### PR TITLE
Generate root-relative links for to() directives to the same host

### DIFF
--- a/src/routers/content.js
+++ b/src/routers/content.js
@@ -28,7 +28,23 @@ ContentFilterService.add(function (input, next) {
   if (content.envelope && content.envelope.body) {
     content.envelope.body = content.envelope.body.replace(
       urlDirectiveRx,
-      (match, contentID) => ContentRoutingService.getPresentedUrl(context, contentID)
+      (match, contentID) => {
+        const original = ContentRoutingService.getPresentedUrl(context, contentID);
+        const parsed = url.parse(original);
+
+        if (parsed.host === context.host()) {
+          delete parsed.protocol;
+          delete parsed.hostname;
+          delete parsed.host;
+          delete parsed.port;
+          parsed.slashes = false;
+        }
+
+        const final = url.format(parsed);
+
+        logger.debug('Replacing to() directive', { match, contentID, destination: final });
+        return final;
+      }
     );
   }
 

--- a/src/services/content/index.js
+++ b/src/services/content/index.js
@@ -172,7 +172,7 @@ var ContentService = {
       });
 
       doc.results = doc.results.filter(function (each) {
-        each.url = ContentRoutingService.getPresentedUrl(context, each.contentID, true);
+        each.url = ContentRoutingService.getPresentedUrl(context, each.contentID);
         return each.url !== null;
       });
 

--- a/src/services/content/routing.js
+++ b/src/services/content/routing.js
@@ -141,21 +141,12 @@ const ContentRoutingService = {
 
     return mappings;
   },
-  getPresentedUrl: function (context, contentID, crossDomain) {
-    let domain = null;
-    let onlyFirst = false;
-
-    if (!crossDomain) {
-      domain = context.host();
-      onlyFirst = true;
-    }
-
-    let urls = this.getMappingsForContentID(contentID, domain, onlyFirst).map((mapping) => {
+  getPresentedUrl: function (context, contentID) {
+    let urls = this.getMappingsForContentID(contentID, null, true).map((mapping) => {
       return UrlService.getSiteUrl(context, mapping.path, mapping.domain);
     });
 
     if (urls.length === 0) return null;
-
     return urls[0];
   },
   getProxies: function (context) {

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -275,13 +275,29 @@ describe('page assembly', function () {
       .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
       .reply(200, {
         assets: [],
+        envelope: { body: "with a {{ to('https://github.com/deconst-dog/fake/some/page') }} reference" }
+      });
+
+    request(server.create())
+      .get('/')
+      .expect(200)
+      .expect(/with a https:\/\/deconst\.dog\/some\/page\/ reference/, done);
+  });
+
+  it('substitutes {{ to() }} directives with root-relative links for same-domain mappings', (done) => {
+    nock('http://content')
+      .get('/control').reply(200, { sha: null })
+      .get('/assets').reply(200, {})
+      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake')
+      .reply(200, {
+        assets: [],
         envelope: { body: "with a {{ to('https://github.com/deconst/subrepo/some/page') }} reference" }
       });
 
     request(server.create())
       .get('/')
       .expect(200)
-      .expect(/with a https:\/\/deconst\.horse\/subrepo\/some\/page\/ reference/, done);
+      .expect(/with a \/subrepo\/some\/page\/ reference/, done);
   });
 
   it('fetches envelope addenda', (done) => {


### PR DESCRIPTION
If the target of a `{{ to('<content-id>') }}` directive within envelope content maps to a path on the same domain as that of the current request context, generate a root-relative link instead of an absolute one.

Fixes #133.
