### PR TITLE
Cross-domain template re-use

### DIFF
--- a/src/services/nunjucks/index.js
+++ b/src/services/nunjucks/index.js
@@ -28,9 +28,7 @@ var NunjucksService = {
   clearEnvironments: function () {
     envs = {};
   },
-  getEnvironment: function (context, callback) {
-    var domain = context.host();
-
+  getEnvironment: function (domain, callback) {
     if (!envs[domain]) {
       logger.warn('Missing environment for domain', {
         domain: domain
@@ -40,6 +38,9 @@ var NunjucksService = {
     }
 
     callback(null, envs[domain]);
+  },
+  hasEnvironment: function (domain) {
+    return domain in envs;
   },
   installEnvironment: function (domain, loaders, plugins) {
     var env = createEnvironment(domain, loaders);

--- a/test/assembly.js
+++ b/test/assembly.js
@@ -268,6 +268,22 @@ describe('page assembly', function () {
       .expect(/not on staging/, done);
   });
 
+  it('permits cross-domain template re-use', (done) => {
+    nock('http://content')
+      .get('/control').reply(200, { sha: null })
+      .get('/assets').reply(200, {})
+      .get('/content/https%3A%2F%2Fgithub.com%2Fdeconst%2Ffake%2Fxdomain')
+      .reply(200, {
+        assets: [],
+        envelope: { body: 'xdomain page' }
+      });
+
+    request(server.create())
+      .get('/xdomain/')
+      .expect(200)
+      .expect(/in deconst\.dog/, done);
+  });
+
   it('substitutes {{ to() }} directives', (done) => {
     nock('http://content')
       .get('/control').reply(200, { sha: null })

--- a/test/test-control/config/routes.json
+++ b/test/test-control/config/routes.json
@@ -7,7 +7,8 @@
             "^/searchcats/?$": "searchcats.html",
             "^/with-template-link/?$": "link.html",
             "^/am-i-staging/$": "isstaging.html",
-            "^/original/$": "addenda.html"
+            "^/original/$": "addenda.html",
+            "^/xdomain/?$": "deconst.dog/default.html"
         }
     },
     "deconst.dog": {


### PR DESCRIPTION
Permit template re-use across domains in the control repository when a hostname is explicitly specified.

Fixes #118.
